### PR TITLE
Add noColors option to matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,17 @@ Jest matcher that performs image comparisons using [Blink-diff](https://github.c
 
 ### Optional configuration:
 
-`toMatchImageSnapshot()` takes an optional options object where you can provide your own [blink-diff configuration parameters](http://yahoo.github.io/blink-diff/#object-usage) and/or a custom snapshot identifier string:
+`toMatchImageSnapshot()` takes an optional options object where you can provide your own [blink-diff configuration parameters](http://yahoo.github.io/blink-diff/#object-usage) and/or a custom snapshot identifier string and/or forcing no styled output for possibly storing the results in a file:
 
 ```javascript
   it('should demonstrate this matcher`s usage with a custom blink-diff config', () => {
     ...
     const blinkDiffConfig = { perceptual: true };
-    expect(image).toMatchImageSnapshot({ customDiffConfig: blinkDiffConfig, customSnapshotIdentifier: 'customSnapshotName' });
+    expect(image).toMatchImageSnapshot({ 
+      customDiffConfig: blinkDiffConfig, 
+      customSnapshotIdentifier: 'customSnapshotName', 
+      noColors: true // the default is false
+    });
   });  
 ```
 

--- a/__tests__/src/__snapshots__/index.spec.js.snap
+++ b/__tests__/src/__snapshots__/index.spec.js.snap
@@ -21,3 +21,8 @@ exports[`toMatchImageSnapshot should fail when snapshot has a difference beyond 
 `;
 
 exports[`toMatchImageSnapshot should throw an error if used with .not matcher 1`] = `"Jest: \`.not\` cannot be used with \`.toMatchImageSnapshot()\`."`;
+
+exports[`toMatchImageSnapshot should use noColors options if passed as true and not style error message 2`] = `
+"Expected image to match or be a close match to snapshot.
+See diff for details: path/to/result.png"
+`;

--- a/__tests__/src/index.spec.js
+++ b/__tests__/src/index.spec.js
@@ -68,6 +68,18 @@ describe('toMatchImageSnapshot', () => {
       .toThrowErrorMatchingSnapshot();
   });
 
+  it('should use noColors options if passed as true and not style error message', () => {
+    // code 1 is result too different: https://github.com/yahoo/blink-diff/blob/master/index.js#L267
+    const mockDiffResult = { updated: false, code: 1, diffOutputPath: 'path/to/result.png' };
+    setupMock(mockDiffResult);
+    const { toMatchImageSnapshot } = require('../../src/index');
+    expect.extend({ toMatchImageSnapshot });
+
+
+    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot({ noColors: true }))
+      .toThrowErrorMatchingSnapshot();
+  });
+
   it('should use custom blink-diff configuration if passed in', () => {
     const mockTestContext = {
       testPath: 'path/to/test.spec.js',

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@
 const kebabCase = require('lodash/kebabCase');
 const merge = require('lodash/merge');
 const path = require('path');
-const chalk = require('chalk');
+const Chalk = require('chalk').constructor;
 const { diffImageToSnapshot } = require('./diff-snapshot');
 
 function updateSnapshotState(oldSnapshotState, newSnapshotState) {
@@ -24,6 +24,8 @@ function updateSnapshotState(oldSnapshotState, newSnapshotState) {
 
 function toMatchImageSnapshot(received, { customSnapshotIdentifier = '', customDiffConfig = {}, noColors = false } = {}) {
   const { testPath, currentTestName, isNot } = this;
+  const chalk = new Chalk({ enabled: !noColors });
+
   let { snapshotState } = this;
   if (isNot) { throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.'); }
 
@@ -49,11 +51,8 @@ function toMatchImageSnapshot(received, { customSnapshotIdentifier = '', customD
     pass = false;
   }
 
-  const message = noColors
-    ? 'Expected image to match or be a close match to snapshot.\n'
-      + `See diff for details: ${result.diffOutputPath}`
-    : 'Expected image to match or be a close match to snapshot.\n'
-      + `${chalk.bold.red('See diff for details:')} ${chalk.red(result.diffOutputPath)}`;
+  const message = 'Expected image to match or be a close match to snapshot.\n'
+                  + `${chalk.bold.red('See diff for details:')} ${chalk.red(result.diffOutputPath)}`;
 
   return {
     message,

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function updateSnapshotState(oldSnapshotState, newSnapshotState) {
   return merge({}, oldSnapshotState, newSnapshotState);
 }
 
-function toMatchImageSnapshot(received, { customSnapshotIdentifier = '', customDiffConfig = {} } = {}) {
+function toMatchImageSnapshot(received, { customSnapshotIdentifier = '', customDiffConfig = {}, noColors = false } = {}) {
   const { testPath, currentTestName, isNot } = this;
   let { snapshotState } = this;
   if (isNot) { throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.'); }
@@ -49,8 +49,11 @@ function toMatchImageSnapshot(received, { customSnapshotIdentifier = '', customD
     pass = false;
   }
 
-  const message = 'Expected image to match or be a close match to snapshot.\n'
-                  + `${chalk.bold.red('See diff for details:')} ${chalk.red(result.diffOutputPath)}`;
+  const message = noColors
+    ? 'Expected image to match or be a close match to snapshot.\n'
+      + `See diff for details: ${result.diffOutputPath}`
+    : 'Expected image to match or be a close match to snapshot.\n'
+      + `${chalk.bold.red('See diff for details:')} ${chalk.red(result.diffOutputPath)}`;
 
   return {
     message,


### PR DESCRIPTION
Using some jasmine/jest reporters (for example jasmine-trx-reporter) will fail because of using chalk.
chalk doesn't realize the terminal doesn't support color.

This adds the option for the outcome of the test would not have styling inside of it.