### PR TITLE
docs(README): adds TravisCI build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # jest-image-snapshot
 
-[![npm version](https://badge.fury.io/js/jest-image-snapshot.svg)](https://badge.fury.io/js/jest-image-snapshot)
+[
+  ![npm version](https://badge.fury.io/js/jest-image-snapshot.svg)](https://badge.fury.io/js/jest-image-snapshot
+) [
+  ![Build Status](https://travis-ci.org/americanexpress/jest-image-snapshot.svg?branch=master)](https://travis-ci.org/americanexpress/jest-image-snapshot
+)
 
 Jest matcher that performs image comparisons using [Blink-diff](https://github.com/yahoo/blink-diff) and behaves just like [Jest snapshots](https://facebook.github.io/jest/docs/snapshot-testing.html) do! Very useful for browser visual comparison testing.
 


### PR DESCRIPTION
* master branch for the build badge, though for publishes maybe each version should generate the `README` and use the tag?
* kept the badges on the same line, but also tried to make the markdown a bit readable: avoided having a very long line