### PR TITLE
Mentions in README that customSnapshotsDir is absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Jest matcher that performs image comparisons using [pixelmatch](https://github.c
 * `customDiffConfig`: Custom config passed [pixelmatch](https://github.com/mapbox/pixelmatch#pixelmatchimg1-img2-output-width-height-options) (See options section)
   * By default we have set the `threshold` to 0.01, you can increase that value by passing a customDiffConfig as demonstrated below.
   * Please note the `threshold` set in the `customDiffConfig` is the per pixel sensitivity threshold. For example with a source pixel colour of `#ffffff` (white) and a comparison pixel colour of `#fcfcfc` (really light grey) if you set the threshold to 0 then it would trigger a failure *on that pixel*. However if you were to use say 0.5 then it wouldn't, the colour difference would need to be much more extreme to trigger a failure on that pixel, say `#000000` (black)
-* `customSnapshotsDir`: (default: `__image_snapshots__`) A custom directory to keep this snapshot in
+* `customSnapshotsDir`: (default: `__image_snapshots__`) A custom absolute path of a directory to keep this snapshot in
 * `customSnapshotIdentifier`: A custom name to give this snapshot. If not provided one is computed automatically
 * `noColors`: (default `false`) Removes colouring from console output, useful if storing the results in a file
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.


### PR DESCRIPTION
This updates the README to address some confusion I had with #29.