### PR TITLE
Update pngjs for Node 9 support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "pixelmatch": "^4.0.2",
-    "pngjs": "^3.3.0"
+    "pngjs": "^3.3.2"
   },
   "peerDependencies": {
     "jest": ">=20 <=22"


### PR DESCRIPTION
pngjs now works with Node 9. This updates the minimum dependency.

https://github.com/lukeapage/pngjs/issues/95#issuecomment-369823886
https://github.com/lukeapage/pngjs/pull/102