### PR TITLE
fix(diff-snapshot): Fix stringify failure due to circular referneces.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "8"
   - "6"
+  - "8"
+  - "9"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "pixelmatch": "^4.0.2",
-    "pngjs": "https://github.com/skywhale/pngjs/archive/fixnode9.tar.gz",
+    "pngjs": "^3.3.3",
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "pixelmatch": "^4.0.2",
-    "pngjs": "^3.3.0",
+    "//": "DO NOT SUBMIT: Remove after the PR is merged.",
+    "pngjs": "https://github.com/skywhale/pngjs/archive/fixnode9.tar.gz",
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "pixelmatch": "^4.0.2",
-    "//": "DO NOT SUBMIT: Remove after the PR is merged.",
     "pngjs": "https://github.com/skywhale/pngjs/archive/fixnode9.tar.gz",
     "rimraf": "^2.6.2"
   },

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -158,9 +158,7 @@ function diffImageToSnapshot(options) {
       const input = { imagePath: diffOutputPath, image: compositeResultImage };
       // image._packer property contains a circular reference since node9, causing JSON.stringify to
       // fail. Might as well discard all the hidden properties.
-      const serializedInput = JSON.stringify(input, function(name, val) {
-        return name[0] === '_' ? undefined : val;
-      });
+      const serializedInput = JSON.stringify(input, (name, val) => (name[0] === '_' ? undefined : val));
 
       // writing diff in separate process to avoid perf issues associated with Math in Jest VM (https://github.com/facebook/jest/issues/5163)
       const writeDiffProcess = childProcess.spawnSync('node', [`${__dirname}/write-result-diff-image.js`], { input: Buffer.from(serializedInput) });


### PR DESCRIPTION
Since node 9, PNG._packer._handle.jsref has a circular reference, causing JSON.stringify to fail. Since none of the hidden properties starting with _ aren't needed for writing the images, I went ahead and discarded them all.