### PR TITLE
Display n° of unmatched snapshots in the snapshot summary + "u" usage suggestion

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -35,6 +35,8 @@ describe('toMatchImageSnapshot', () => {
   }
 
   beforeEach(() => {
+    // In tests, skip reporting (snapshotState update to not mess with our test report)
+    global.skipReporting = true;
     jest.resetModules();
     jest.resetAllMocks();
   });
@@ -360,5 +362,16 @@ describe('toMatchImageSnapshot', () => {
     expect(Chalk).toHaveBeenCalledWith({
       enabled: false,
     });
+  });
+});
+
+describe('updateSnapshotState', () => {
+  it('mutates original state', () => {
+    const { updateSnapshotState } = require('../src/index');
+    global.skipReporting = false;
+    const originalState = { some: 'value' };
+    updateSnapshotState(originalState, { another: 'val' });
+
+    expect(originalState).toEqual({ some: 'value', another: 'val' });
   });
 });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -35,8 +35,8 @@ describe('toMatchImageSnapshot', () => {
   }
 
   beforeEach(() => {
-    // In tests, skip reporting (snapshotState update to not mess with our test report)
-    global.skipReporting = true;
+    // In tests, skip reporting (skip snapshotState update to not mess with our test report)
+    global.UNSTABLE_SKIP_REPORTING = true;
     jest.resetModules();
     jest.resetAllMocks();
   });
@@ -368,7 +368,7 @@ describe('toMatchImageSnapshot', () => {
 describe('updateSnapshotState', () => {
   it('mutates original state', () => {
     const { updateSnapshotState } = require('../src/index');
-    global.skipReporting = false;
+    global.UNSTABLE_SKIP_REPORTING = false;
     const originalState = { some: 'value' };
     updateSnapshotState(originalState, { another: 'val' });
 

--- a/__tests__/integration.spec.js
+++ b/__tests__/integration.spec.js
@@ -29,8 +29,8 @@ describe('toMatchImageSnapshot', () => {
   const diffExists = identifier => fs.existsSync(path.join(__dirname, diffOutputDir(), `${identifier}-diff.png`));
 
   beforeAll(() => {
-    // In tests, skip reporting (snapshotState update to not mess with our test report)
-    global.skipReporting = true;
+    // In tests, skip reporting (skip snapshotState update to not mess with our test report)
+    global.UNSTABLE_SKIP_REPORTING = true;
     const { toMatchImageSnapshot } = require('../src'); // eslint-disable-line global-require
     expect.extend({ toMatchImageSnapshot });
   });

--- a/__tests__/integration.spec.js
+++ b/__tests__/integration.spec.js
@@ -29,6 +29,8 @@ describe('toMatchImageSnapshot', () => {
   const diffExists = identifier => fs.existsSync(path.join(__dirname, diffOutputDir(), `${identifier}-diff.png`));
 
   beforeAll(() => {
+    // In tests, skip reporting (snapshotState update to not mess with our test report)
+    global.skipReporting = true;
     const { toMatchImageSnapshot } = require('../src'); // eslint-disable-line global-require
     expect.extend({ toMatchImageSnapshot });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const fs = require('fs');
 const SNAPSHOTS_DIR = '__image_snapshots__';
 
 function updateSnapshotState(originalSnapshotState, partialSnapshotState) {
-  if (global.skipReporting) {
+  if (global.UNSTABLE_SKIP_REPORTING) {
     return originalSnapshotState;
   }
   return merge(originalSnapshotState, partialSnapshotState);

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ const fs = require('fs');
 const SNAPSHOTS_DIR = '__image_snapshots__';
 
 function updateSnapshotState(originalSnapshotState, partialSnapshotState) {
+  if (global.skipReporting) {
+    return originalSnapshotState;
+  }
   return merge(originalSnapshotState, partialSnapshotState);
 }
 
@@ -39,11 +42,13 @@ function configureToMatchImageSnapshot({
     failureThreshold = commonFailureThreshold,
     failureThresholdType = commonFailureThresholdType,
   } = {}) {
-    const { testPath, currentTestName, isNot } = this;
+    const {
+      testPath, currentTestName, isNot, snapshotState,
+    } = this;
     const chalk = new Chalk({ enabled: !noColors });
 
-    const { snapshotState } = this;
     if (isNot) { throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.'); }
+
 
     updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
     const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
@@ -105,4 +110,5 @@ function configureToMatchImageSnapshot({
 module.exports = {
   toMatchImageSnapshot: configureToMatchImageSnapshot(),
   configureToMatchImageSnapshot,
+  updateSnapshotState,
 };


### PR DESCRIPTION
Hi there, this is my attempt to fix https://github.com/americanexpress/jest-image-snapshot/issues/61

# Goal 
- Have the "snapshot summary" with correct informations about _unmatched_ number of snapshots.
- Have the "u" & "i" usage suggestions in Jest watch mode. (update snapshot)

# How
- I updated the counter of the "unmatched" snapshots in the singleton `snapshotState` when images differs.
- I also refactored a little the `updateSnapshotState`, I hope you don't mind... there was a mix between merging & assigning to the singleton (the one & only snapshotState Jest is aware of and bases its report on)

# Results
- Jest now displays the number of _unmatched_ snapshots + hints about the "u" to update snapshots.

# How to test
- Edit a test, change the rendering, Jest should display `› 1 snapshot test failed in 1 test suite. Inspect your code changes or press `u` to update them.`

Let me know if you need anything else to have this merge. Thanks!
