### PR TITLE
Add new matcher .toThrowErrorMatchingImageSnapshot

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -12,14 +12,4 @@ Object {
 }
 `;
 
-exports[`toMatchImageSnapshot should fail when snapshot has a difference beyond allowed threshold 2`] = `
-"Expected image to match or be a close match to snapshot but was 80% different from snapshot (600 differing pixels).
-[1m[31mSee diff for details:[39m[22m [31mpath/to/result.png[39m"
-`;
-
 exports[`toMatchImageSnapshot should throw an error if used with .not matcher 1`] = `"Jest: \`.not\` cannot be used with \`.toMatchImageSnapshot()\`."`;
-
-exports[`toMatchImageSnapshot should use noColors options if passed as true and not style error message 2`] = `
-"Expected image to match or be a close match to snapshot but was 40% different from snapshot (600 differing pixels).
-See diff for details: path/to/result.png"
-`;

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -84,11 +84,10 @@ describe('toMatchImageSnapshot', () => {
     };
 
     setupMock(mockDiffResult);
-    const { toMatchImageSnapshot } = require('../src/index');
-    expect.extend({ toMatchImageSnapshot });
+    const { toThrowErrorMatchingImageSnapshot } = require('../src/index');
+    expect.extend({ toThrowErrorMatchingImageSnapshot });
 
-    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot())
-      .toThrowErrorMatchingSnapshot();
+    expect('pretendthisisanimagebuffer').toThrowErrorMatchingImageSnapshot();
   });
 
   it('should use noColors options if passed as true and not style error message', () => {
@@ -100,11 +99,10 @@ describe('toMatchImageSnapshot', () => {
     };
 
     setupMock(mockDiffResult);
-    const { toMatchImageSnapshot } = require('../src/index');
-    expect.extend({ toMatchImageSnapshot });
+    const { toThrowErrorMatchingImageSnapshot } = require('../src/index');
+    expect.extend({ toThrowErrorMatchingImageSnapshot });
 
-    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot({ noColors: true }))
-      .toThrowErrorMatchingSnapshot();
+    expect('pretendthisisanimagebuffer').toThrowErrorMatchingImageSnapshot({ noColors: true });
   });
 
   it('should use custom pixelmatch configuration if passed in', () => {
@@ -338,7 +336,7 @@ describe('toMatchImageSnapshot', () => {
     }));
     const { configureToMatchImageSnapshot } = require('../src/index');
     const customConfig = { perceptual: true };
-    const toMatchImageSnapshot = configureToMatchImageSnapshot({
+    const { toMatchImageSnapshot } = configureToMatchImageSnapshot({
       customDiffConfig: customConfig,
       noColors: true,
     });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -255,6 +255,33 @@ describe('toMatchImageSnapshot', () => {
     expect(mockDiff).toHaveBeenCalled();
   });
 
+  it('should fail when a snapshot is beyond threshold', () => {
+    const mockTestContext = {
+      testPath: 'path/to/test.spec.js',
+      currentTestName: 'test1',
+      isNot: false,
+      snapshotState: {
+        _counters: new Map(),
+        update: false,
+        pass: false,
+        updated: undefined,
+        added: false,
+      },
+    };
+
+    const mockDiffResult = { updated: false, pass: false };
+
+    setupMock(mockDiffResult);
+
+    const { toMatchImageSnapshot } = require('../src/index');
+    const matcherAtTest = toMatchImageSnapshot.bind(mockTestContext);
+    const result = matcherAtTest('pretendthisisanimagebuffer');
+
+    expect(result).toHaveProperty('pass', false);
+    expect(result).toHaveProperty('message');
+    expect(result.message()).toContain('Expected image to match');
+  });
+
   it('should fail when a new snapshot is added in ci', () => {
     const mockTestContext = {
       testPath: 'path/to/test.spec.js',
@@ -459,7 +486,7 @@ describe('toMatchImageSnapshot', () => {
       diffPixelCount: 600,
     };
 
-    const Chalk = function () {
+    const Chalk = function Chalk() {
       return {
         bold: { red: text => text },
         red: text => text,

--- a/__tests__/integration.spec.js
+++ b/__tests__/integration.spec.js
@@ -29,8 +29,9 @@ describe('toMatchImageSnapshot', () => {
   const diffExists = identifier => fs.existsSync(path.join(__dirname, diffOutputDir(), `${identifier}-diff.png`));
 
   beforeAll(() => {
-    const { toMatchImageSnapshot } = require('../src'); // eslint-disable-line global-require
+    const { toMatchImageSnapshot, toThrowErrorMatchingImageSnapshot } = require('../src'); // eslint-disable-line global-require
     expect.extend({ toMatchImageSnapshot });
+    expect.extend({ toThrowErrorMatchingImageSnapshot });
   });
 
   beforeEach(() => {
@@ -98,9 +99,12 @@ describe('toMatchImageSnapshot', () => {
       ).not.toThrowError();
 
       // Test against a different image
-      expect(
-        () => expect(failImageData).toMatchImageSnapshot({ customSnapshotIdentifier })
-      ).toThrowError(expectedError);
+      expect(failImageData).toThrowErrorMatchingImageSnapshot(
+        {
+          customSnapshotIdentifier,
+          expectedException: expectedError,
+        }
+      );
     });
 
     it('fails with a differently sized images and outputs diff', () => {
@@ -112,9 +116,14 @@ describe('toMatchImageSnapshot', () => {
       ).not.toThrowError();
 
       // Test against an image much larger than the snapshot.
-      expect(
-        () => expect(oversizeImageData).toMatchImageSnapshot({ customSnapshotIdentifier })
-      ).toThrowError(/Expected image to match or be a close match to snapshot but was 83\.85395537525355% different from snapshot/);
+
+      expect(oversizeImageData).toThrowErrorMatchingImageSnapshot(
+        {
+          customSnapshotIdentifier,
+          expectedException: /Expected image to match or be a close match to snapshot but was 83\.85395537525355% different from snapshot/,
+        }
+      );
+
 
       expect(diffExists(customSnapshotIdentifier)).toBe(true);
     });
@@ -126,9 +135,13 @@ describe('toMatchImageSnapshot', () => {
         () => expect(imageData).toMatchImageSnapshot({ customSnapshotIdentifier })
       ).not.toThrowError();
 
-      expect(
-        () => expect(biggerImageData).toMatchImageSnapshot({ customSnapshotIdentifier })
-      ).toThrowError(/Expected image to match or be a close match to snapshot but was 54\.662222222222226% different from snapshot/);
+
+      expect(biggerImageData).toThrowErrorMatchingImageSnapshot(
+        {
+          customSnapshotIdentifier,
+          expectedException: /Expected image to match or be a close match to snapshot but was 54\.662222222222226% different from snapshot/,
+        }
+      );
 
       expect(diffExists(customSnapshotIdentifier)).toBe(true);
     });
@@ -142,9 +155,7 @@ describe('toMatchImageSnapshot', () => {
       ).not.toThrowError();
 
       // then test against a different image
-      expect(
-        () => expect(failImageData).toMatchImageSnapshot({ customSnapshotIdentifier })
-      ).toThrow();
+      expect(failImageData).toThrowErrorMatchingImageSnapshot({ customSnapshotIdentifier });
 
       expect(fs.existsSync(pathToResultImage)).toBe(true);
 
@@ -161,9 +172,7 @@ describe('toMatchImageSnapshot', () => {
       ).not.toThrowError();
 
       // then test against a different image (to generate a results image)
-      expect(
-        () => expect(failImageData).toMatchImageSnapshot({ customSnapshotIdentifier })
-      ).toThrow();
+      expect(failImageData).toThrowErrorMatchingImageSnapshot({ customSnapshotIdentifier });
 
       // then test against image that should not generate results image (as it is passing test)
       expect(

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,35 @@
 /* eslint-disable no-underscore-dangle */
 const kebabCase = require('lodash/kebabCase');
 const merge = require('lodash/merge');
+const isRegExp = require('lodash/isRegExp');
 const path = require('path');
 const Chalk = require('chalk').constructor;
 const { diffImageToSnapshot } = require('./diff-snapshot');
 const fs = require('fs');
 
 const SNAPSHOTS_DIR = '__image_snapshots__';
+
+function getReadOnlyMessage(chalk) {
+  return `New snapshot was ${chalk.bold.red('not written')}. The update flag must be explicitly ` +
+  'passed to write a new snapshot.\n\n + This is likely because this test is run in a continuous ' +
+  'integration (CI) environment in which snapshots are not written by default.\n\n';
+}
+
+function getInconsistentSnapshotsMessage(
+  chalk, { differencePercentage, diffOutputPath, diffPixelCount }
+) {
+  return `Expected image to match or be a close match to snapshot but was ${differencePercentage}% different from snapshot (${diffPixelCount} differing pixels).\n`
+  + `${chalk.bold.red('See diff for details:')} ${chalk.red(diffOutputPath)}`;
+}
+
+function matchesException(expected, received) {
+  if (isRegExp(expected)) {
+    return expected.test(received);
+  }
+
+  // eslint-disable-next-line eqeqeq
+  return expected == received;
+}
 
 function updateSnapshotState(originalSnapshotState, partialSnapshotState) {
   return merge(originalSnapshotState, partialSnapshotState);
@@ -31,78 +54,148 @@ function configureToMatchImageSnapshot({
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
 } = {}) {
-  return function toMatchImageSnapshot(received, {
-    customSnapshotIdentifier = '',
-    customSnapshotsDir,
-    customDiffConfig = {},
-    noColors = commonNoColors,
-    failureThreshold = commonFailureThreshold,
-    failureThresholdType = commonFailureThresholdType,
-  } = {}) {
-    const { testPath, currentTestName, isNot } = this;
-    const chalk = new Chalk({ enabled: !noColors });
+  return {
+    toMatchImageSnapshot: function toMatchImageSnapshot(received, {
+      customSnapshotIdentifier = '',
+      customSnapshotsDir,
+      customDiffConfig = {},
+      noColors = commonNoColors,
+      failureThreshold = commonFailureThreshold,
+      failureThresholdType = commonFailureThresholdType,
+    } = {}) {
+      const { testPath, currentTestName, isNot } = this;
+      const chalk = new Chalk({ enabled: !noColors });
 
-    const { snapshotState } = this;
-    if (isNot) { throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.'); }
-
-    updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
-    const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
-
-    const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
-    const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
-
-    if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
-      return {
-        pass: false,
-        message: () => `New snapshot was ${chalk.bold.red('not written')}. The update flag must be explicitly ` +
-        'passed to write a new snapshot.\n\n + This is likely because this test is run in a continuous ' +
-        'integration (CI) environment in which snapshots are not written by default.\n\n',
-      };
-    }
-
-    const result =
-      diffImageToSnapshot({
-        receivedImageBuffer: received,
-        snapshotsDir,
-        snapshotIdentifier,
-        updateSnapshot: snapshotState._updateSnapshot === 'all',
-        customDiffConfig: Object.assign({}, commonCustomDiffConfig, customDiffConfig),
-        failureThreshold,
-        failureThresholdType,
-      });
-
-    let pass = true;
-    /*
-      istanbul ignore next
-      `message` is implementation detail. Actual behavior is tested in integration.spec.js
-    */
-    let message = () => '';
-
-    if (result.updated) {
-      // once transition away from jasmine is done this will be a lot more elegant and pure
-      // https://github.com/facebook/jest/pull/3668
-      updateSnapshotState(snapshotState, { updated: snapshotState.updated + 1 });
-    } else if (result.added) {
-      updateSnapshotState(snapshotState, { added: snapshotState.added + 1 });
-    } else {
-      ({ pass } = result);
-
-      if (!pass) {
-        updateSnapshotState(snapshotState, { unmatched: snapshotState.unmatched + 1 });
-        const differencePercentage = result.diffRatio * 100;
-        message = () => `Expected image to match or be a close match to snapshot but was ${differencePercentage}% different from snapshot (${result.diffPixelCount} differing pixels).\n`
-                  + `${chalk.bold.red('See diff for details:')} ${chalk.red(result.diffOutputPath)}`;
+      const { snapshotState } = this;
+      if (isNot) {
+        throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.');
       }
-    }
 
-    return {
-      message,
-      pass,
-    };
+      updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
+      const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
+
+      const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
+      const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
+
+      if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
+        return {
+          pass: false,
+          message: () => getReadOnlyMessage(chalk),
+        };
+      }
+
+      const result =
+        diffImageToSnapshot({
+          receivedImageBuffer: received,
+          snapshotsDir,
+          snapshotIdentifier,
+          updateSnapshot: snapshotState._updateSnapshot === 'all',
+          customDiffConfig: Object.assign({}, commonCustomDiffConfig, customDiffConfig),
+          failureThreshold,
+          failureThresholdType,
+        });
+
+      let pass = true;
+      /*
+        istanbul ignore next
+        `message` is implementation detail. Actual behavior is tested in integration.spec.js
+      */
+      let message = () => '';
+
+      if (result.updated) {
+        // once transition away from jasmine is done this will be a lot more elegant and pure
+        // https://github.com/facebook/jest/pull/3668
+        updateSnapshotState(snapshotState, { updated: snapshotState.updated + 1 });
+      } else if (result.added) {
+        updateSnapshotState(snapshotState, { added: snapshotState.added + 1 });
+      } else {
+        ({ pass } = result);
+
+        if (!pass) {
+          updateSnapshotState(snapshotState, { unmatched: snapshotState.unmatched + 1 });
+          const differencePercentage = result.diffRatio * 100;
+          message = () => getInconsistentSnapshotsMessage(chalk, {
+            diffOutputPath: result.diffOutputPath,
+            differencePercentage,
+            diffPixelCount: result.diffPixelCount,
+          });
+        }
+      }
+
+      return {
+        message,
+        pass,
+      };
+    },
+    toThrowErrorMatchingImageSnapshot: function toThrowErrorMatchingImageSnapshot(received, {
+      customSnapshotIdentifier = '',
+      customSnapshotsDir,
+      customDiffConfig = {},
+      noColors = commonNoColors,
+      failureThreshold = commonFailureThreshold,
+      failureThresholdType = commonFailureThresholdType,
+      expectedException,
+    } = {}) {
+      const { testPath, currentTestName, isNot } = this;
+      const chalk = new Chalk({ enabled: !noColors });
+
+      const { snapshotState } = this;
+      if (isNot) {
+        throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.');
+      }
+
+      updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
+      const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
+
+      const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
+      const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
+
+      if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
+        const readOnlyMessage = getReadOnlyMessage(chalk);
+        return {
+          pass: expectedException ? matchesException(expectedException, readOnlyMessage) : true,
+          message: () => readOnlyMessage,
+        };
+      }
+
+      const result =
+        diffImageToSnapshot({
+          receivedImageBuffer: received,
+          snapshotsDir,
+          snapshotIdentifier,
+          updateSnapshot: snapshotState._updateSnapshot === 'all',
+          customDiffConfig: Object.assign({}, commonCustomDiffConfig, customDiffConfig),
+          failureThreshold,
+          failureThresholdType,
+        });
+
+      if (!result.updated && !result.added && !result.pass) {
+        const differencePercentage = result.diffRatio * 100;
+        const message = getInconsistentSnapshotsMessage(chalk, {
+          diffOutputPath: result.diffOutputPath,
+          differencePercentage,
+          diffPixelCount: result.diffPixelCount,
+        });
+
+        const shouldPass = expectedException ? matchesException(expectedException, message) : true;
+        return {
+          message: () => (shouldPass ? '' : `Expected exception is not matching received exception: ${message}`),
+          pass: shouldPass,
+        };
+      }
+
+      return {
+        message: () => 'Expected image comparison to throw but snapshots were the same.\n',
+        pass: false,
+      };
+    },
   };
 }
 
+const defaultMatchers = configureToMatchImageSnapshot();
+
 module.exports = {
-  toMatchImageSnapshot: configureToMatchImageSnapshot(),
+  toMatchImageSnapshot: defaultMatchers.toMatchImageSnapshot,
+  toThrowErrorMatchingImageSnapshot: defaultMatchers.toThrowErrorMatchingImageSnapshot,
   configureToMatchImageSnapshot,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -35,14 +35,14 @@ function getInconsistentSnapshotsMessage(
   + `${chalk.bold.red('See diff for details:')} ${chalk.red(diffOutputPath)}`;
 }
 
-function matchesException(expected, received) {
+const matchesException = (expected, received) => {
   if (isRegExp(expected)) {
     return expected.test(received);
   }
 
   // eslint-disable-next-line eqeqeq
   return expected == received;
-}
+};
 
 function updateSnapshotState(originalSnapshotState, partialSnapshotState) {
   return merge(originalSnapshotState, partialSnapshotState);
@@ -54,37 +54,36 @@ function configureToMatchImageSnapshot({
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
 } = {}) {
-  return {
-    toMatchImageSnapshot: function toMatchImageSnapshot(received, {
-      customSnapshotIdentifier = '',
-      customSnapshotsDir,
-      customDiffConfig = {},
-      noColors = commonNoColors,
-      failureThreshold = commonFailureThreshold,
-      failureThresholdType = commonFailureThresholdType,
-    } = {}) {
-      const { testPath, currentTestName, isNot } = this;
-      const chalk = new Chalk({ enabled: !noColors });
+  return function toMatchImageSnapshot(received, {
+    customSnapshotIdentifier = '',
+    customSnapshotsDir,
+    customDiffConfig = {},
+    noColors = commonNoColors,
+    failureThreshold = commonFailureThreshold,
+    failureThresholdType = commonFailureThresholdType,
+  } = {}) {
+    const { testPath, currentTestName, isNot } = this;
+    const chalk = new Chalk({ enabled: !noColors });
 
-      const { snapshotState } = this;
-      if (isNot) {
-        throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.');
-      }
+    const { snapshotState } = this;
+    if (isNot) {
+      throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.');
+    }
 
-      updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
-      const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
+    updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
+    const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
 
-      const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
-      const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
+    const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
+    const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
 
-      if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
-        return {
-          pass: false,
-          message: () => getReadOnlyMessage(chalk),
-        };
-      }
+    if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
+      return {
+        pass: false,
+        message: () => getReadOnlyMessage(chalk),
+      };
+    }
 
-      const result =
+    const result =
         diffImageToSnapshot({
           receivedImageBuffer: received,
           snapshotsDir,
@@ -95,107 +94,120 @@ function configureToMatchImageSnapshot({
           failureThresholdType,
         });
 
-      let pass = true;
-      /*
+    let pass = true;
+    /*
         istanbul ignore next
         `message` is implementation detail. Actual behavior is tested in integration.spec.js
       */
-      let message = () => '';
+    let message = () => '';
 
-      if (result.updated) {
-        // once transition away from jasmine is done this will be a lot more elegant and pure
-        // https://github.com/facebook/jest/pull/3668
-        updateSnapshotState(snapshotState, { updated: snapshotState.updated + 1 });
-      } else if (result.added) {
-        updateSnapshotState(snapshotState, { added: snapshotState.added + 1 });
-      } else {
-        ({ pass } = result);
+    if (result.updated) {
+      // once transition away from jasmine is done this will be a lot more elegant and pure
+      // https://github.com/facebook/jest/pull/3668
+      updateSnapshotState(snapshotState, { updated: snapshotState.updated + 1 });
+    } else if (result.added) {
+      updateSnapshotState(snapshotState, { added: snapshotState.added + 1 });
+    } else {
+      ({ pass } = result);
 
-        if (!pass) {
-          updateSnapshotState(snapshotState, { unmatched: snapshotState.unmatched + 1 });
-          const differencePercentage = result.diffRatio * 100;
-          message = () => getInconsistentSnapshotsMessage(chalk, {
-            diffOutputPath: result.diffOutputPath,
-            differencePercentage,
-            diffPixelCount: result.diffPixelCount,
-          });
-        }
-      }
-
-      return {
-        message,
-        pass,
-      };
-    },
-    toThrowErrorMatchingImageSnapshot: function toThrowErrorMatchingImageSnapshot(received, {
-      customSnapshotIdentifier = '',
-      customSnapshotsDir,
-      customDiffConfig = {},
-      noColors = commonNoColors,
-      failureThreshold = commonFailureThreshold,
-      failureThresholdType = commonFailureThresholdType,
-      expectedException,
-    } = {}) {
-      const { testPath, currentTestName, isNot } = this;
-      const chalk = new Chalk({ enabled: !noColors });
-
-      const { snapshotState } = this;
-      if (isNot) {
-        throw new Error('Jest: `.not` cannot be used with `.toMatchImageSnapshot()`.');
-      }
-
-      updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
-      const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
-
-      const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
-      const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
-
-      if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
-        const readOnlyMessage = getReadOnlyMessage(chalk);
-        return {
-          pass: expectedException ? matchesException(expectedException, readOnlyMessage) : true,
-          message: () => readOnlyMessage,
-        };
-      }
-
-      const result =
-        diffImageToSnapshot({
-          receivedImageBuffer: received,
-          snapshotsDir,
-          snapshotIdentifier,
-          updateSnapshot: snapshotState._updateSnapshot === 'all',
-          customDiffConfig: Object.assign({}, commonCustomDiffConfig, customDiffConfig),
-          failureThreshold,
-          failureThresholdType,
-        });
-
-      if (!result.updated && !result.added && !result.pass) {
+      if (!pass) {
+        updateSnapshotState(snapshotState, { unmatched: snapshotState.unmatched + 1 });
         const differencePercentage = result.diffRatio * 100;
-        const message = getInconsistentSnapshotsMessage(chalk, {
+        message = () => getInconsistentSnapshotsMessage(chalk, {
           diffOutputPath: result.diffOutputPath,
           differencePercentage,
           diffPixelCount: result.diffPixelCount,
         });
-
-        const shouldPass = expectedException ? matchesException(expectedException, message) : true;
-        return {
-          message: () => (shouldPass ? '' : `Expected exception is not matching received exception: ${message}`),
-          pass: shouldPass,
-        };
       }
+    }
 
-      return {
-        message: () => 'Expected image comparison to throw but snapshots were the same.\n',
-        pass: false,
-      };
-    },
+    return {
+      message,
+      pass,
+    };
   };
 }
 
-const defaultMatchers = configureToMatchImageSnapshot();
+
+function configureToThrowErrorMatchingImageSnapshot({
+  customDiffConfig: commonCustomDiffConfig = {},
+  noColors: commonNoColors = false,
+  failureThreshold: commonFailureThreshold = 0,
+  failureThresholdType: commonFailureThresholdType = 'pixel',
+} = {}) {
+  return function toThrowErrorMatchingImageSnapshot(received, {
+    customSnapshotIdentifier = '',
+    customSnapshotsDir,
+    customDiffConfig = {},
+    noColors = commonNoColors,
+    failureThreshold = commonFailureThreshold,
+    failureThresholdType = commonFailureThresholdType,
+    expectedException,
+  } = {}) {
+    const { testPath, currentTestName, isNot } = this;
+    const chalk = new Chalk({ enabled: !noColors });
+
+    const { snapshotState } = this;
+    if (isNot) {
+      throw new Error('Jest: `.not` cannot be used with `.toThrowErrorMatchingImageSnapshot()`.');
+    }
+
+    updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
+    const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
+
+    const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
+    const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
+
+    if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
+      const readOnlyMessage = getReadOnlyMessage(chalk);
+      return {
+        pass: expectedException ? matchesException(expectedException, readOnlyMessage) : true,
+        message: () => readOnlyMessage,
+      };
+    }
+
+    const result =
+        diffImageToSnapshot({
+          receivedImageBuffer: received,
+          snapshotsDir,
+          snapshotIdentifier,
+          updateSnapshot: snapshotState._updateSnapshot === 'all',
+          customDiffConfig: Object.assign({}, commonCustomDiffConfig, customDiffConfig),
+          failureThreshold,
+          failureThresholdType,
+        });
+
+    if (!result.updated && !result.added && !result.pass) {
+      const differencePercentage = result.diffRatio * 100;
+      const message = getInconsistentSnapshotsMessage(chalk, {
+        diffOutputPath: result.diffOutputPath,
+        differencePercentage,
+        diffPixelCount: result.diffPixelCount,
+      });
+
+      const shouldPass = expectedException ? matchesException(expectedException, message) : true;
+      const errorMessage = shouldPass ?
+        '' :
+        `Expected exception is not matching received exception. Expected: "${message}" but received: "${expectedException}"`;
+
+      return {
+        message: () => errorMessage,
+        pass: shouldPass,
+      };
+    }
+
+    return {
+      message: () => 'Expected image comparison to throw but snapshots were the same.\n',
+      pass: false,
+    };
+  };
+}
+
+const toMatchImageSnapshot = configureToMatchImageSnapshot();
+const toThrowErrorMatchingImageSnapshot = configureToThrowErrorMatchingImageSnapshot();
 
 module.exports = {
-  toMatchImageSnapshot: defaultMatchers.toMatchImageSnapshot,
-  toThrowErrorMatchingImageSnapshot: defaultMatchers.toThrowErrorMatchingImageSnapshot,
+  toMatchImageSnapshot,
+  toThrowErrorMatchingImageSnapshot,
   configureToMatchImageSnapshot,
 };


### PR DESCRIPTION
# Goal
- Testing error matching. Just like https://facebook.github.io/jest/docs/en/expect.html#tothrowerrormatchingsnapshot

### Before
```js
    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot())
      .toThrow();
``` 
### After
```js
expect('pretendthisisanimagebuffer').toThrowErrorMatchingImageSnapshot();
``` 

# How 
- Added the method, and some tweaks.

This is a draft, I based this branch on top of my previous contribution (https://github.com/americanexpress/jest-image-snapshot/pull/77) but I will clean-up things tomorrow.

I'm open to discussion around the implementation & strategy to do this well.