### PR TITLE
fix(package): support jest v23

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Jest matcher that performs image comparisons using [pixelmatch](https://github.c
   npm i --save-dev jest-image-snapshot
   ```
 
-  Please note that `Jest` `>=20 <=22` is a peerDependency. `jest-image-snapshot` will **not** work with anything below Jest 20.x.x
+  Please note that `Jest` `>=20 <=23` is a peerDependency. `jest-image-snapshot` will **not** work with anything below Jest 20.x.x
 
 ## Usage:
 1. Extend Jest's `expect`

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^4.15.0",
     "eslint-config-amex": "^7.0.0",
     "is-png": "^1.1.0",
-    "jest": "^22.0.0",
+    "jest": "^23.0.0",
     "mock-spawn": "^0.2.6"
   },
   "dependencies": {
@@ -59,6 +59,6 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "jest": ">=20 <=22"
+    "jest": ">=20 <=23"
   }
 }


### PR DESCRIPTION
Jest v23 [has been released](https://github.com/facebook/jest/blob/master/CHANGELOG.md#2300), but isn't allowed in the specified range as a peer dependency. This change expands the range to include v23, and also updates the version as a dev dependency to run tests on the latest version.