### PR TITLE
feat(configuration): add updatePassedSnapshot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
 * `noColors`: (default `false`) Removes colouring from console output, useful if storing the results in a file
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
+* `updatePassedSnapshot`: (default `true`) Updates a snapshot even if it matched the existing one.
 
 ```javascript
   it('should demonstrate this matcher`s usage with a custom pixelmatch config', () => {

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -8,6 +8,7 @@ Object {
   "receivedImageBuffer": "pretendthisisanimagebuffer",
   "snapshotIdentifier": "test-spec-js-test-1",
   "snapshotsDir": "path/to/__image_snapshots__",
+  "updatePassedSnapshot": true,
   "updateSnapshot": false,
 }
 `;

--- a/__tests__/diff-snapshot.spec.js
+++ b/__tests__/diff-snapshot.spec.js
@@ -366,6 +366,21 @@ describe('diff-snapshot', () => {
       expect(diffResult).toHaveProperty('updated', true);
     });
 
+    it('should return pass flag if snapshot was not updated due to updatePassedSnapshot', () => {
+      const diffImageToSnapshot = setupTest({ snapshotExists: true });
+      const diffResult = diffImageToSnapshot({
+        receivedImageBuffer: mockImageBuffer,
+        snapshotIdentifier: mockSnapshotIdentifier,
+        snapshotsDir: mockSnapshotsDir,
+        updateSnapshot: true,
+        updatePassedSnapshot: false,
+        failureThreshold: 0,
+        failureThresholdType: 'pixel',
+      });
+
+      expect(diffResult).toHaveProperty('pass', true);
+    });
+
     it('should return added flag is snapshot was added', () => {
       const diffImageToSnapshot = setupTest({ snapshotExists: false });
       const diffResult = diffImageToSnapshot({

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -357,6 +357,7 @@ describe('toMatchImageSnapshot', () => {
       snapshotIdentifier: 'test-spec-js-test-1-1',
       snapshotsDir: path.join('path', 'to', 'my-custom-snapshots-dir'),
       updateSnapshot: false,
+      updatePassedSnapshot: true,
       failureThreshold: 0,
       failureThresholdType: 'pixel',
     });

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ function configureToMatchImageSnapshot({
   noColors: commonNoColors = false,
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
+  updatePassedSnapshot: commonUpdatePassedSnapshot = true,
 } = {}) {
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = '',
@@ -42,6 +43,7 @@ function configureToMatchImageSnapshot({
     noColors = commonNoColors,
     failureThreshold = commonFailureThreshold,
     failureThresholdType = commonFailureThresholdType,
+    updatePassedSnapshot = commonUpdatePassedSnapshot,
   } = {}) {
     const {
       testPath, currentTestName, isNot, snapshotState,
@@ -72,6 +74,7 @@ function configureToMatchImageSnapshot({
         snapshotsDir,
         snapshotIdentifier,
         updateSnapshot: snapshotState._updateSnapshot === 'all',
+        updatePassedSnapshot,
         customDiffConfig: Object.assign({}, commonCustomDiffConfig, customDiffConfig),
         failureThreshold,
         failureThresholdType,


### PR DESCRIPTION
Related #74 

It adds an `updatePassedSnapshot` option which. If set to false, it prevents jest-image-snapshot from updating the snapshot.
It's particularly usefull when you set a treshold value to ignore negligible diff between environments (like font rendering). It will avoid the commit (or revert) of useless changes.

The `handlePassedSnapshot` function has only been created in order to reduce cyclomatic complexity.