### PR TITLE
Enhance serialization speed to save 3s on diff writing.

### DIFF
--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -164,15 +164,18 @@ function diffImageToSnapshot(options) {
         readable,
       } = compositeResultImage;
 
-      const imagePartial = JSON.stringify({
-        width, height, gamma, writable, readable,
-      });
-
-      const imageFull = `${imagePartial.slice(0, imagePartial.length - 1)},"data":"${data.toString('base64')}"}`;
-
-      const inputPartial = JSON.stringify({ imagePath: diffOutputPath });
-
-      const serializedInput = `${inputPartial.slice(0, inputPartial.length - 1)}, "image": ${imageFull}}`;
+      // JSON.stringify is very slow with large strings
+      const serializedInput = `{
+        "imagePath":"${diffOutputPath}",
+        "image":{
+          "width":"${width}",
+          "height":"${height}",
+          "gamma":"${gamma}",
+          "writable":"${writable}",
+          "readable":"${readable}",
+          "data":"${data.toString('base64')}"
+        }
+      }`;
 
       // writing diff in separate process to avoid perf issues associated with Math in Jest VM (https://github.com/facebook/jest/issues/5163)
       const writeDiffProcess = childProcess.spawnSync('node', [`${__dirname}/write-result-diff-image.js`], { input: Buffer.from(serializedInput) });

--- a/src/write-result-diff-image.js
+++ b/src/write-result-diff-image.js
@@ -21,7 +21,7 @@ getStdin.buffer().then((buffer) => {
     const input = JSON.parse(buffer);
     const { imagePath, image } = input;
 
-    image.data = Buffer.from(image.data);
+    image.data = Buffer.from(image.data, 'base64');
 
     const pngBuffer = PNG.sync.write(image);
     fs.writeFileSync(imagePath, pngBuffer);


### PR DESCRIPTION
This may resolve #87. Although I'm not sure I addressed the specific regression this reduces the time spent when writing a diff image for me by slightly more than 3 seconds.

I now get ~2 seconds spent in the expect operation when a difference is detected and can get a further 600ms by reducing the threshold used with pixelmatch to 0.1 .

I suspect pixel match may also be suffering from the vm globals issue, however I have not checked verified this.

I have verified that placing a variant of `const Math = Math` at the top of every pngjs source file that uses math with foil the vm issue.. It may be worth asking politely if these changes can be introduced into pixelmatch and pngjs.