### PR TITLE
Out of proc

### DIFF
--- a/__tests__/diff-snapshot.spec.js
+++ b/__tests__/diff-snapshot.spec.js
@@ -161,9 +161,9 @@ describe('diff-snapshot', () => {
         { threshold: 0.01 }
       );
 
-      expect(mockSpawn.calls[0].args[0]).toBe(path.resolve('./src/write-result-diff-image.js'));
-      expect(mockSpawn.calls[0].command).toBe('node');
-      expect(mockSpawn.calls[0].opts.input).toEqual(expect.any(Buffer));
+      // expect(mockSpawn.calls[0].args[0]).toBe(path.resolve('./src/write-result-diff-image.js'));
+      // expect(mockSpawn.calls[0].command).toBe('node');
+      // expect(mockSpawn.calls[0].opts.input).toEqual(expect.any(Buffer));
     });
 
     it('should pass <= failureThreshold pixel', () => {

--- a/__tests__/diff-snapshot.spec.js
+++ b/__tests__/diff-snapshot.spec.js
@@ -15,12 +15,45 @@
 /* eslint-disable global-require */
 const fs = require('fs');
 const path = require('path');
-const mockSpawn = require('mock-spawn')();
 
 describe('diff-snapshot', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.resetAllMocks();
+  });
+
+  describe('runDiffImageToSNapshot', () => {
+    const mockSpawnSync = jest.fn();
+    const fakeRequest = {
+      receivedImageBuffer: Buffer.from('abcdefg'),
+      snapshotIdentifier: 'foo',
+      snapshotsDir: 'bar',
+      updateSnapshot: false,
+      failureThreshold: 0,
+      failureThresholdType: 'pixel',
+    };
+
+    function setupTest(spawnReturn) {
+      mockSpawnSync.mockReturnValue(spawnReturn);
+      jest.mock('child_process', () => ({ spawnSync: mockSpawnSync }));
+      const { runDiffImageToSnapshot } = require('../src/diff-snapshot');
+      return runDiffImageToSnapshot;
+    }
+
+    it('runs external process and returns result', () => {
+      const runDiffImageToSnapshot = setupTest({
+        status: 0, output: [null, null, null, JSON.stringify({ add: true, updated: false })],
+      });
+
+      expect(runDiffImageToSnapshot(fakeRequest)).toEqual({ add: true, updated: false });
+
+      expect(mockSpawnSync).toBeCalled();
+    });
+
+    it('throws when process returns a non-zero status', () => {
+      const runDiffImageToSnapshot = setupTest({ status: 1 });
+      expect(() => runDiffImageToSnapshot(fakeRequest)).toThrow();
+    });
   });
 
   describe('diffImageToSnapshot', () => {
@@ -34,6 +67,7 @@ describe('diff-snapshot', () => {
     const mockMkdirpSync = jest.fn();
     const mockWriteFileSync = jest.fn();
     const mockPixelMatch = jest.fn();
+
 
     function setupTest({
       snapshotDirExists,
@@ -49,8 +83,6 @@ describe('diff-snapshot', () => {
         readFileSync: jest.fn(),
       });
 
-      mockSpawn.setDefault(mockSpawn.simple(0));
-      jest.mock('child_process', () => ({ spawnSync: mockSpawn }));
       jest.mock('fs', () => mockFs);
       jest.mock('mkdirp', () => ({ sync: mockMkdirpSync }));
       const { diffImageToSnapshot } = require('../src/diff-snapshot');
@@ -131,7 +163,7 @@ describe('diff-snapshot', () => {
       // Check that pixelmatch was called
       expect(mockPixelMatch).toHaveBeenCalledTimes(1);
       // Check that that it did not attempt to write a diff
-      expect(mockSpawn.calls).toEqual([]);
+      expect(mockWriteFileSync.mock.calls).toEqual([]);
     });
 
     it('should write a diff image if the test fails', () => {
@@ -161,9 +193,7 @@ describe('diff-snapshot', () => {
         { threshold: 0.01 }
       );
 
-      // expect(mockSpawn.calls[0].args[0]).toBe(path.resolve('./src/write-result-diff-image.js'));
-      // expect(mockSpawn.calls[0].command).toBe('node');
-      // expect(mockSpawn.calls[0].opts.input).toEqual(expect.any(Buffer));
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
     });
 
     it('should pass <= failureThreshold pixel', () => {

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -136,7 +136,7 @@ describe('toMatchImageSnapshot', () => {
     const customDiffConfig = { threshold: 0.3 };
     matcherAtTest('pretendthisisanimagebuffer', { customDiffConfig });
     const { runDiffImageToSnapshot } = require('../src/diff-snapshot');
-    expect( runDiffImageToSnapshot.mock.calls[0][0].customDiffConfig).toEqual(customDiffConfig);
+    expect(runDiffImageToSnapshot.mock.calls[0][0].customDiffConfig).toEqual(customDiffConfig);
   });
 
   it('passes diffImageToSnapshot everything it needs to create a snapshot and compare if needed', () => {

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -19,7 +19,7 @@ const path = require('path');
 describe('toMatchImageSnapshot', () => {
   function setupMock(diffImageToSnapshotResult) {
     jest.doMock('../src/diff-snapshot', () => ({
-      diffImageToSnapshot: jest.fn(() => diffImageToSnapshotResult),
+      runDiffImageToSnapshot: jest.fn(() => diffImageToSnapshotResult),
     }));
 
     const mockFs = Object.assign({}, fs, {
@@ -135,8 +135,8 @@ describe('toMatchImageSnapshot', () => {
 
     const customDiffConfig = { threshold: 0.3 };
     matcherAtTest('pretendthisisanimagebuffer', { customDiffConfig });
-    const { diffImageToSnapshot } = require('../src/diff-snapshot');
-    expect(diffImageToSnapshot.mock.calls[0][0].customDiffConfig).toEqual(customDiffConfig);
+    const { runDiffImageToSnapshot } = require('../src/diff-snapshot');
+    expect( runDiffImageToSnapshot.mock.calls[0][0].customDiffConfig).toEqual(customDiffConfig);
   });
 
   it('passes diffImageToSnapshot everything it needs to create a snapshot and compare if needed', () => {
@@ -164,9 +164,9 @@ describe('toMatchImageSnapshot', () => {
     const matcherAtTest = toMatchImageSnapshot.bind(mockTestContext);
 
     matcherAtTest('pretendthisisanimagebuffer');
-    const { diffImageToSnapshot } = require('../src/diff-snapshot');
+    const { runDiffImageToSnapshot } = require('../src/diff-snapshot');
 
-    const dataArg = diffImageToSnapshot.mock.calls[0][0];
+    const dataArg = runDiffImageToSnapshot.mock.calls[0][0];
     // This is to make the test work on windows
     dataArg.snapshotsDir = dataArg.snapshotsDir.replace(/\\/g, '/');
 
@@ -198,9 +198,9 @@ describe('toMatchImageSnapshot', () => {
     const matcherAtTest = toMatchImageSnapshot.bind(mockTestContext);
 
     matcherAtTest('pretendthisisanimagebuffer', { customSnapshotIdentifier: 'custom-name' });
-    const { diffImageToSnapshot } = require('../src/diff-snapshot');
+    const { runDiffImageToSnapshot } = require('../src/diff-snapshot');
 
-    expect(diffImageToSnapshot.mock.calls[0][0].snapshotIdentifier).toBe('custom-name');
+    expect(runDiffImageToSnapshot.mock.calls[0][0].snapshotIdentifier).toBe('custom-name');
   });
 
   it('attempts to update snapshots if snapshotState has updateSnapshot flag set', () => {
@@ -222,9 +222,9 @@ describe('toMatchImageSnapshot', () => {
     const matcherAtTest = toMatchImageSnapshot.bind(mockTestContext);
 
     matcherAtTest('pretendthisisanimagebuffer');
-    const { diffImageToSnapshot } = require('../src/diff-snapshot');
+    const { runDiffImageToSnapshot } = require('../src/diff-snapshot');
 
-    expect(diffImageToSnapshot.mock.calls[0][0].updateSnapshot).toBe(true);
+    expect(runDiffImageToSnapshot.mock.calls[0][0].updateSnapshot).toBe(true);
   });
 
   it('should work when a new snapshot is added', () => {
@@ -242,7 +242,7 @@ describe('toMatchImageSnapshot', () => {
     };
     const mockDiff = jest.fn();
     jest.doMock('../src/diff-snapshot', () => ({
-      diffImageToSnapshot: mockDiff,
+      runDiffImageToSnapshot: mockDiff,
     }));
 
     const mockFs = Object.assign({}, fs, {
@@ -329,9 +329,9 @@ describe('toMatchImageSnapshot', () => {
     };
     setupMock({ updated: true });
 
-    const diffImageToSnapshot = jest.fn(() => ({}));
+    const runDiffImageToSnapshot = jest.fn(() => ({}));
     jest.doMock('../src/diff-snapshot', () => ({
-      diffImageToSnapshot,
+      runDiffImageToSnapshot,
     }));
 
     const Chalk = jest.fn();
@@ -350,7 +350,7 @@ describe('toMatchImageSnapshot', () => {
 
     matcherAtTest();
 
-    expect(diffImageToSnapshot).toHaveBeenCalledWith({
+    expect(runDiffImageToSnapshot).toHaveBeenCalledWith({
       customDiffConfig: {
         perceptual: true,
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "preset": "amex-jest-preset",
     "collectCoverageFrom": [
       "src/*.js",
-      "!src/write-result-diff-image.js",
+      "!src/diff-process.js",
       "!**/node_modules/**",
       "!test-results/**"
     ],
@@ -46,8 +46,7 @@
     "eslint": "^4.15.0",
     "eslint-config-amex": "^7.0.0",
     "is-png": "^1.1.0",
-    "jest": "^23.0.0",
-    "mock-spawn": "^0.2.6"
+    "jest": "^23.0.0"
   },
   "dependencies": {
     "chalk": "^1.1.3",

--- a/src/diff-process.js
+++ b/src/diff-process.js
@@ -12,7 +12,7 @@
  * the License.
  */
 
-const fs = require('fs')
+const fs = require('fs');
 
 const getStdin = require('get-stdin');
 

--- a/src/diff-process.js
+++ b/src/diff-process.js
@@ -25,7 +25,6 @@ getStdin.buffer().then((buffer) => {
     options.receivedImageBuffer = Buffer.from(options.receivedImageBuffer, 'base64');
 
     const result = diffImageToSnapshot(options);
-    /* eslint-disable no-console */
 
     fs.writeSync(3, Buffer.from(JSON.stringify(result)));
 

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -164,15 +164,18 @@ function diffImageToSnapshot(options) {
         readable,
       } = compositeResultImage;
 
-      const imagePartial = JSON.stringify({
-        width, height, gamma, writable, readable,
-      });
-
-      const imageFull = `${imagePartial.slice(0, imagePartial.length - 1)},"data":"${data.toString('base64')}"}`;
-
-      const inputPartial = JSON.stringify({ imagePath: diffOutputPath });
-
-      const serializedInput = `${inputPartial.slice(0, inputPartial.length - 1)}, "image": ${imageFull}}`;
+      // JSON.stringify is very slow with large strings
+      const serializedInput = `{
+        "imagePath":"${diffOutputPath}",
+        "image":{
+          "width":"${width}",
+          "height":"${height}",
+          "gamma":"${gamma}",
+          "writable":"${writable}",
+          "readable":"${readable}",
+          "data":"${data.toString('base64')}"
+        }
+      }`;
 
       // writing diff in separate process to avoid perf issues associated with Math in Jest VM (https://github.com/facebook/jest/issues/5163)
       const writeDiffProcess = childProcess.spawnSync('node', [`${__dirname}/write-result-diff-image.js`], { input: Buffer.from(serializedInput) });

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -178,25 +178,9 @@ function diffImageToSnapshot(options) {
 
 
 function runDiffImageToSnapshot(options) {
-  const {
-    receivedImageBuffer,
-    snapshotIdentifier,
-    snapshotsDir,
-    updateSnapshot = false,
-    customDiffConfig = {},
-    failureThreshold,
-    failureThresholdType,
-  } = options;
+  options.receivedImageBuffer = options.receivedImageBuffer.toString('base64');
 
-  const serializedInput = `{
-    "receivedImageBuffer":"${receivedImageBuffer.toString('base64')}",
-    "snapshotIdentifier":"${snapshotIdentifier}",
-    "snapshotsDir":"${snapshotsDir}",
-    "updateSnapshot":${updateSnapshot},
-    "customDiffConfig":${JSON.stringify(customDiffConfig)},
-    "failureThreshold":${failureThreshold},
-    "failureThresholdType":"${failureThresholdType}"
-  }`;
+  const serializedInput = JSON.stringify(options);
 
   let result = {};
   const writeDiffProcess = childProcess.spawnSync('node', [`${__dirname}/write-result-diff-image.js`], { input: Buffer.from(serializedInput) });

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -21,7 +21,6 @@ const pixelmatch = require('pixelmatch');
 const { PNG } = require('pngjs');
 const rimraf = require('rimraf');
 
-
 /**
  * Helper function to create reusable image resizer
  */

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -157,7 +157,7 @@ function diffImageToSnapshot(options) {
         receivedImage, compositeResultImage, 0, 0, imageWidth, imageHeight, imageWidth * 2, 0
       );
       // Set filter type to Paeth to avoid expensive auto scanline filter detection
-      const pngBuffer = PNG.sync.write(compositeResultImage, {filterType: 4});
+      const pngBuffer = PNG.sync.write(compositeResultImage, { filterType: 4 });
       fs.writeFileSync(diffOutputPath, pngBuffer);
     }
 
@@ -173,7 +173,7 @@ function diffImageToSnapshot(options) {
 
     result = updateSnapshot ? { updated: true } : { added: true };
   }
-  return result
+  return result;
 }
 
 
@@ -196,19 +196,20 @@ function runDiffImageToSnapshot(options) {
     "customDiffConfig":${JSON.stringify(customDiffConfig)},
     "failureThreshold":${failureThreshold},
     "failureThresholdType":"${failureThresholdType}"
-  }`
+  }`;
 
-    let result = {};
-    const writeDiffProcess = childProcess.spawnSync('node', [`${__dirname}/write-result-diff-image.js`], { input: Buffer.from(serializedInput) });
-    if (writeDiffProcess.status == 0) {
-      result = JSON.parse(writeDiffProcess.stdout.toString())
-    }
+  let result = {};
+  const writeDiffProcess = childProcess.spawnSync('node', [`${__dirname}/write-result-diff-image.js`], { input: Buffer.from(serializedInput) });
+  if (writeDiffProcess.status === 0) {
+    result = JSON.parse(writeDiffProcess.stdout.toString());
+  }
 
-    if (writeDiffProcess.stderr.toString()) {
-      console.log(writeDiffProcess.stderr.toString())
-    }
+  if (writeDiffProcess.stderr.toString()) {
+    /* eslint-disable no-console */
+    console.log(writeDiffProcess.stderr.toString());
+  }
 
-    return result;
+  return result;
 }
 
 module.exports = {

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -185,7 +185,7 @@ function runDiffImageToSnapshot(options) {
   let result = {};
 
   const writeDiffProcess = childProcess.spawnSync(
-    'node', [`${__dirname}/write-result-diff-image.js`],
+    'node', [`${__dirname}/diff-process.js`],
     { input: Buffer.from(serializedInput), stdio: ['pipe', 'inherit', 'inherit', 'pipe'] }
   );
 

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -183,14 +183,17 @@ function runDiffImageToSnapshot(options) {
   const serializedInput = JSON.stringify(options);
 
   let result = {};
-  const writeDiffProcess = childProcess.spawnSync('node', [`${__dirname}/write-result-diff-image.js`], { input: Buffer.from(serializedInput) });
-  if (writeDiffProcess.status === 0) {
-    result = JSON.parse(writeDiffProcess.stdout.toString());
-  }
 
-  if (writeDiffProcess.stderr.toString()) {
-    /* eslint-disable no-console */
-    console.log(writeDiffProcess.stderr.toString());
+  const writeDiffProcess = childProcess.spawnSync(
+    'node', [`${__dirname}/write-result-diff-image.js`],
+    { input: Buffer.from(serializedInput), stdio: ['pipe', 'inherit', 'inherit', 'pipe'] }
+  );
+
+  if (writeDiffProcess.status === 0) {
+    const output = writeDiffProcess.output[3].toString();
+    result = JSON.parse(output);
+  } else {
+    throw new Error('Error running image diff.');
   }
 
   return result;

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const kebabCase = require('lodash/kebabCase');
 const merge = require('lodash/merge');
 const path = require('path');
 const Chalk = require('chalk').constructor;
-const { diffImageToSnapshot } = require('./diff-snapshot');
+const { runDiffImageToSnapshot } = require('./diff-snapshot');
 const fs = require('fs');
 
 const SNAPSHOTS_DIR = '__image_snapshots__';
@@ -67,7 +67,7 @@ function configureToMatchImageSnapshot({
     }
 
     const result =
-      diffImageToSnapshot({
+      runDiffImageToSnapshot({
         receivedImageBuffer: received,
         snapshotsDir,
         snapshotIdentifier,

--- a/src/write-result-diff-image.js
+++ b/src/write-result-diff-image.js
@@ -12,22 +12,22 @@
  * the License.
  */
 
-const { PNG } = require('pngjs');
-const fs = require('fs');
 const getStdin = require('get-stdin');
+
+const { diffImageToSnapshot } = require('./diff-snapshot')
 
 getStdin.buffer().then((buffer) => {
   try {
-    const input = JSON.parse(buffer);
-    const { imagePath, image } = input;
+    let options = JSON.parse(buffer)
+    
+    options.receivedImageBuffer = Buffer.from(options.receivedImageBuffer, 'base64')
 
-    image.data = Buffer.from(image.data, 'base64');
-
-    const pngBuffer = PNG.sync.write(image);
-    fs.writeFileSync(imagePath, pngBuffer);
-    process.exit(0);
+    const result = diffImageToSnapshot(options)
+  
+    console.log(JSON.stringify(result))
+    process.exit(0)
   } catch (error) {
     console.error(error); // eslint-disable-line no-console
     process.exit(1);
   }
-});
+})

--- a/src/write-result-diff-image.js
+++ b/src/write-result-diff-image.js
@@ -12,6 +12,8 @@
  * the License.
  */
 
+const fs = require('fs')
+
 const getStdin = require('get-stdin');
 
 const { diffImageToSnapshot } = require('./diff-snapshot');
@@ -24,7 +26,9 @@ getStdin.buffer().then((buffer) => {
 
     const result = diffImageToSnapshot(options);
     /* eslint-disable no-console */
-    console.log(JSON.stringify(result));
+
+    fs.writeSync(3, Buffer.from(JSON.stringify(result)));
+
     process.exit(0);
   } catch (error) {
     console.error(error); // eslint-disable-line no-console

--- a/src/write-result-diff-image.js
+++ b/src/write-result-diff-image.js
@@ -21,7 +21,7 @@ getStdin.buffer().then((buffer) => {
     const input = JSON.parse(buffer);
     const { imagePath, image } = input;
 
-    image.data = Buffer.from(image.data);
+    image.data = Buffer.from(image.data, 'base64');
 
     const pngBuffer = PNG.sync.write(image);
     fs.writeFileSync(imagePath, pngBuffer);

--- a/src/write-result-diff-image.js
+++ b/src/write-result-diff-image.js
@@ -14,20 +14,20 @@
 
 const getStdin = require('get-stdin');
 
-const { diffImageToSnapshot } = require('./diff-snapshot')
+const { diffImageToSnapshot } = require('./diff-snapshot');
 
 getStdin.buffer().then((buffer) => {
   try {
-    let options = JSON.parse(buffer)
-    
-    options.receivedImageBuffer = Buffer.from(options.receivedImageBuffer, 'base64')
+    const options = JSON.parse(buffer);
 
-    const result = diffImageToSnapshot(options)
-  
-    console.log(JSON.stringify(result))
-    process.exit(0)
+    options.receivedImageBuffer = Buffer.from(options.receivedImageBuffer, 'base64');
+
+    const result = diffImageToSnapshot(options);
+    /* eslint-disable no-console */
+    console.log(JSON.stringify(result));
+    process.exit(0);
   } catch (error) {
     console.error(error); // eslint-disable-line no-console
     process.exit(1);
   }
-})
+});


### PR DESCRIPTION
This is an alternative to PR #88 and is a consolidation of all the knowledge I gained while looking into performance issues.

My testing results in a 3570x869 diff image.

All said this gets me down to ~`420ms` vs ~`5095ms` on master  for total matcher time when images differ with default settings.

**Paeth filter used for converting raw image to bytes**
The auto selection process loops over EVERY byte in the raw image information for every filter option in order to select the best filter on a per-line basis. File size may not be optimal but this cuts the time to pack the file down to 1/4th for me; ~60ms vs ~270ms.

**All image ops run out of process**
Pixelmatch and other pngjs operations still rely heavily on Math. Pixelmatch istelf is 8x-10x slower in the Jest isolate environment. For me this is the difference between 100ms and >800ms with the default threshold of `0.01`. I will submit PRs to both projects for caching `Math` into the module scope, however both projects are currently a bit slow on merging..

**Artisinal JSON**
For some reason `JSON.stringify` is incredibly slow when dealing with large buffers/strings. By hand-crafting a payload for the child process we can bypass this slowdown.