### PR TITLE
fix(execution): used exec path to execute spawned diff-snapshot process

### DIFF
--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -200,7 +200,7 @@ function runDiffImageToSnapshot(options) {
   let result = {};
 
   const writeDiffProcess = childProcess.spawnSync(
-    'node', [`${__dirname}/diff-process.js`],
+    process.execPath, [`${__dirname}/diff-process.js`],
     { input: Buffer.from(serializedInput), stdio: ['pipe', 'inherit', 'inherit', 'pipe'] }
   );
 


### PR DESCRIPTION
Change now used process.execPath to ensure that we spawn a new node process to run diff-snapshot if node is not on the environment.

Closes #108