### PR TITLE
feat(options): Add customDiffDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
   * By default we have set the `threshold` to 0.01, you can increase that value by passing a customDiffConfig as demonstrated below.
   * Please note the `threshold` set in the `customDiffConfig` is the per pixel sensitivity threshold. For example with a source pixel colour of `#ffffff` (white) and a comparison pixel colour of `#fcfcfc` (really light grey) if you set the threshold to 0 then it would trigger a failure *on that pixel*. However if you were to use say 0.5 then it wouldn't, the colour difference would need to be much more extreme to trigger a failure on that pixel, say `#000000` (black)
 * `customSnapshotsDir`: A custom absolute path of a directory to keep this snapshot in
+* `customDiffDir`: A custom absolute path of a directory to keep this diff in
 * `customSnapshotIdentifier`: A custom name to give this snapshot. If not provided one is computed automatically
 * `noColors`: (default `false`) Removes colouring from console output, useful if storing the results in a file
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`toMatchImageSnapshot passes diffImageToSnapshot everything it needs to create a snapshot and compare if needed 1`] = `
 Object {
   "customDiffConfig": Object {},
+  "diffDir": "path/to/__image_snapshots__/__diff_output__",
   "failureThreshold": 0,
   "failureThresholdType": "pixel",
   "receivedImageBuffer": "pretendthisisanimagebuffer",

--- a/__tests__/diff-snapshot.spec.js
+++ b/__tests__/diff-snapshot.spec.js
@@ -58,6 +58,7 @@ describe('diff-snapshot', () => {
 
   describe('diffImageToSnapshot', () => {
     const mockSnapshotsDir = path.normalize('/path/to/snapshots');
+    const mockDiffDir = path.normalize('/path/to/snapshots/__diff_output__');
     const mockSnapshotIdentifier = 'id1';
     const mockImagePath = './__tests__/stubs/TestImage.png';
     const mockImageBuffer = fs.readFileSync(mockImagePath);
@@ -92,7 +93,7 @@ describe('diff-snapshot', () => {
         switch (p) {
           case path.join(mockSnapshotsDir, `${mockSnapshotIdentifier}-snap.png`):
             return snapshotExists;
-          case path.join(mockSnapshotsDir, '__diff_output__'):
+          case mockDiffDir:
             return !!outputDirExists;
           case mockSnapshotsDir:
             return !!snapshotDirExists;
@@ -122,6 +123,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -143,6 +145,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -167,6 +170,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockFailImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -197,6 +201,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockBigImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -225,6 +230,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockFailImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 250,
         failureThresholdType: 'pixel',
@@ -241,6 +247,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -257,6 +264,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockFailImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 250,
         failureThresholdType: 'pixel',
@@ -274,6 +282,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockFailImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 250,
         failureThresholdType: 'pixel',
@@ -290,6 +299,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockFailImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0.025,
         failureThresholdType: 'percent',
@@ -306,6 +316,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockFailImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0.025,
         failureThresholdType: 'percent',
@@ -323,6 +334,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -339,6 +351,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         customDiffConfig: {
           threshold: 0.1,
@@ -362,6 +375,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockFailImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
       });
@@ -375,6 +389,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -389,6 +404,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -397,12 +413,13 @@ describe('diff-snapshot', () => {
       expect(mockMkdirSync).not.toHaveBeenCalledWith(path.join(mockSnapshotsDir, '__diff_output__'));
     });
 
-    it('should create snapshots directory is there is not one already', () => {
+    it('should create snapshots directory if there is not one already', () => {
       const diffImageToSnapshot = setupTest({ snapshotExists: true, snapshotDirExists: false });
       diffImageToSnapshot({
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: true,
         updatePassedSnapshot: true,
         failureThreshold: 0,
@@ -418,6 +435,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: true,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -432,6 +450,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -447,6 +466,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: true,
         updatePassedSnapshot: true,
         failureThreshold: 0,
@@ -462,6 +482,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -480,6 +501,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: false,
         failureThreshold: 0,
         failureThresholdType: 'pixel',
@@ -496,6 +518,7 @@ describe('diff-snapshot', () => {
           receivedImageBuffer: mockFailImageBuffer,
           snapshotIdentifier: mockSnapshotIdentifier,
           snapshotsDir: mockSnapshotsDir,
+          diffDir: mockDiffDir,
           updateSnapshot: false,
           failureThreshold: 0,
           failureThresholdType: 'banana',
@@ -510,6 +533,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: true,
         updatePassedSnapshot: false,
         failureThreshold: 0,
@@ -527,6 +551,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: true,
         updatePassedSnapshot: true,
         failureThreshold: 0,
@@ -544,6 +569,7 @@ describe('diff-snapshot', () => {
         receivedImageBuffer: mockFailImageBuffer,
         snapshotIdentifier: mockSnapshotIdentifier,
         snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
         updateSnapshot: true,
         updatePassedSnapshot: false,
         failureThreshold: 0,

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -343,6 +343,7 @@ describe('toMatchImageSnapshot', () => {
     const toMatchImageSnapshot = configureToMatchImageSnapshot({
       customDiffConfig: customConfig,
       customSnapshotsDir: path.join('path', 'to', 'my-custom-snapshots-dir'),
+      customDiffDir: path.join('path', 'to', 'my-custom-diff-dir'),
       noColors: true,
     });
     expect.extend({ toMatchImageSnapshot });
@@ -356,6 +357,7 @@ describe('toMatchImageSnapshot', () => {
       },
       snapshotIdentifier: 'test-spec-js-test-1-1',
       snapshotsDir: path.join('path', 'to', 'my-custom-snapshots-dir'),
+      diffDir: path.join('path', 'to', 'my-custom-diff-dir'),
       updateSnapshot: false,
       updatePassedSnapshot: false,
       failureThreshold: 0,

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -87,6 +87,7 @@ function diffImageToSnapshot(options) {
     receivedImageBuffer,
     snapshotIdentifier,
     snapshotsDir,
+    diffDir,
     updateSnapshot = false,
     updatePassedSnapshot = false,
     customDiffConfig = {},
@@ -101,8 +102,7 @@ function diffImageToSnapshot(options) {
     fs.writeFileSync(baselineSnapshotPath, receivedImageBuffer);
     result = { added: true };
   } else {
-    const outputDir = path.join(snapshotsDir, '__diff_output__');
-    const diffOutputPath = path.join(outputDir, `${snapshotIdentifier}-diff.png`);
+    const diffOutputPath = path.join(diffDir, `${snapshotIdentifier}-diff.png`);
     rimraf.sync(diffOutputPath);
 
     const defaultDiffConfig = {
@@ -159,7 +159,7 @@ function diffImageToSnapshot(options) {
     }
 
     if (isFailure({ pass, updateSnapshot })) {
-      mkdirp.sync(outputDir);
+      mkdirp.sync(diffDir);
       const compositeResultImage = new PNG({
         width: imageWidth * 3,
         height: imageHeight,

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ function updateSnapshotState(originalSnapshotState, partialSnapshotState) {
 function configureToMatchImageSnapshot({
   customDiffConfig: commonCustomDiffConfig = {},
   customSnapshotsDir: commonCustomSnapshotsDir,
+  customDiffDir: commonCustomDiffDir,
   noColors: commonNoColors = false,
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
@@ -39,6 +40,7 @@ function configureToMatchImageSnapshot({
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = '',
     customSnapshotsDir = commonCustomSnapshotsDir,
+    customDiffDir = commonCustomDiffDir,
     customDiffConfig = {},
     noColors = commonNoColors,
     failureThreshold = commonFailureThreshold,
@@ -56,6 +58,7 @@ function configureToMatchImageSnapshot({
     const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
 
     const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
+    const diffDir = customDiffDir || path.join(snapshotsDir, '__diff_output__');
     const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
 
     if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
@@ -71,6 +74,7 @@ function configureToMatchImageSnapshot({
       runDiffImageToSnapshot({
         receivedImageBuffer: received,
         snapshotsDir,
+        diffDir,
         snapshotIdentifier,
         updateSnapshot: snapshotState._updateSnapshot === 'all',
         customDiffConfig: Object.assign({}, commonCustomDiffConfig, customDiffConfig),


### PR DESCRIPTION
Allows a custom diff directory to be set, by passing the `customDiffDir` option.

Closes: #97 