### PR TITLE
new "customSnapshotsFolderName" custom property

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
   * By default we have set the `threshold` to 0.01, you can increase that value by passing a customDiffConfig as demonstrated below.
   * Please note the `threshold` set in the `customDiffConfig` is the per pixel sensitivity threshold. For example with a source pixel colour of `#ffffff` (white) and a comparison pixel colour of `#fcfcfc` (really light grey) if you set the threshold to 0 then it would trigger a failure *on that pixel*. However if you were to use say 0.5 then it wouldn't, the colour difference would need to be much more extreme to trigger a failure on that pixel, say `#000000` (black)
 * `customSnapshotsDir`: A custom absolute path of a directory to keep this snapshot in
+* `customSnapshotsFolderName`: A custom name of a snapshots folder
 * `customDiffDir`: A custom absolute path of a directory to keep this diff in
 * `customSnapshotIdentifier`: A custom name to give this snapshot. If not provided one is computed automatically
 * `noColors`: (default `false`) Removes colouring from console output, useful if storing the results in a file

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ function updateSnapshotState(originalSnapshotState, partialSnapshotState) {
 function configureToMatchImageSnapshot({
   customDiffConfig: commonCustomDiffConfig = {},
   customSnapshotsDir: commonCustomSnapshotsDir,
+  customSnapshotsFolderName: commonCustomSnapshotsFolderName,
   customDiffDir: commonCustomDiffDir,
   noColors: commonNoColors = false,
   failureThreshold: commonFailureThreshold = 0,
@@ -40,6 +41,7 @@ function configureToMatchImageSnapshot({
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = '',
     customSnapshotsDir = commonCustomSnapshotsDir,
+    customSnapshotsFolderName = commonCustomSnapshotsFolderName,
     customDiffDir = commonCustomDiffDir,
     customDiffConfig = {},
     noColors = commonNoColors,
@@ -57,7 +59,7 @@ function configureToMatchImageSnapshot({
     updateSnapshotState(snapshotState, { _counters: snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1) }); // eslint-disable-line max-len
     const snapshotIdentifier = customSnapshotIdentifier || kebabCase(`${path.basename(testPath)}-${currentTestName}-${snapshotState._counters.get(currentTestName)}`);
 
-    const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
+    const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), (customSnapshotsFolderName || SNAPSHOTS_DIR)); // eslint-disable-line max-len
     const diffDir = customDiffDir || path.join(snapshotsDir, '__diff_output__');
     const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
 


### PR DESCRIPTION
added "customSnapshotsFolderName" property to be able to override default snapshots folder name specified in the "SNAPSHOTS_DIR" constant