### PR TITLE
Convert all paths for snapshot based tests.

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -192,6 +192,7 @@ describe('toMatchImageSnapshot', () => {
     const dataArg = runDiffImageToSnapshot.mock.calls[0][0];
     // This is to make the test work on windows
     dataArg.snapshotsDir = dataArg.snapshotsDir.replace(/\\/g, '/');
+    dataArg.diffDir = dataArg.diffDir.replace(/\\/g, '/');
 
     expect(dataArg).toMatchSnapshot();
   });

--- a/src/diff-process.js
+++ b/src/diff-process.js
@@ -26,7 +26,7 @@ getStdin.buffer().then((buffer) => {
 
     const result = diffImageToSnapshot(options);
 
-    fs.writeSync(3, Buffer.from(JSON.stringify(result)));
+    fs.writeSync(3, JSON.stringify(result));
 
     process.exit(0);
   } catch (error) {


### PR DESCRIPTION
This lets the snapshot test in `index.spec.js` pass on Windows - it applies the same mangling as for the other path in the snapshot.