### PR TITLE
updatedFailedSnapshots & customFailedDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 
 # test
 test-results
+__failed__
 __diff_output__
 .jest-cache
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
 * `updatePassedSnapshot`: (default `false`) Updates a snapshot even if it passed the threshold against the existing one.
+* `updateFailedSnapshot`: (default `false`) Updates a snapshot even if it failed (a diff is still created). Recommend: Use the customFailedDir propery. 
+* `customFailedDir`: (defaults to `snapshotDir` or `customSnapshotDir`) A custom absolute path of a directory to store failed screenshots in (if updateFailedSnapshot is set to true) (useful for artifacts in CIs)
 
 ```javascript
   it('should demonstrate this matcher`s usage with a custom pixelmatch config', () => {

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -5,11 +5,13 @@ Object {
   "customDiffConfig": Object {},
   "diffDir": "path/to/__image_snapshots__/__diff_output__",
   "diffDirection": "horizontal",
+  "failedDir": "path/to/__image_snapshots__",
   "failureThreshold": 0,
   "failureThresholdType": "pixel",
   "receivedImageBuffer": "pretendthisisanimagebuffer",
   "snapshotIdentifier": "test-spec-js-test-1",
   "snapshotsDir": "path/to/__image_snapshots__",
+  "updateFailedSnapshot": false,
   "updatePassedSnapshot": false,
   "updateSnapshot": false,
 }

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -380,10 +380,70 @@ describe('toMatchImageSnapshot', () => {
       },
       snapshotIdentifier: 'test-spec-js-test-1-1',
       snapshotsDir: path.join('path', 'to', 'my-custom-snapshots-dir'),
+      failedDir: path.join('path', 'to', 'my-custom-snapshots-dir'),
       diffDir: path.join('path', 'to', 'my-custom-diff-dir'),
       diffDirection: 'horizontal',
       updateSnapshot: false,
       updatePassedSnapshot: false,
+      updateFailedSnapshot: false,
+      failureThreshold: 0,
+      failureThresholdType: 'pixel',
+    });
+    expect(Chalk).toHaveBeenCalledWith({
+      enabled: false,
+    });
+  });
+
+  it('can provide custom defaults for failed tests', () => {
+    const mockTestContext = {
+      testPath: path.join('path', 'to', 'test.spec.js'),
+      currentTestName: 'test1',
+      isNot: false,
+      snapshotState: {
+        _counters: new Map(),
+        update: true,
+        updated: undefined,
+        added: undefined,
+      },
+    };
+    setupMock({ updated: true });
+
+    const runDiffImageToSnapshot = jest.fn(() => ({}));
+    jest.doMock('../src/diff-snapshot', () => ({
+      runDiffImageToSnapshot,
+    }));
+
+    const Chalk = jest.fn();
+    jest.doMock('chalk', () => ({
+      constructor: Chalk,
+    }));
+    const { configureToMatchImageSnapshot } = require('../src/index');
+    const customConfig = { perceptual: true };
+    const toMatchImageSnapshot = configureToMatchImageSnapshot({
+      customDiffConfig: customConfig,
+      customSnapshotsDir: path.join('path', 'to', 'my-custom-snapshots-dir'),
+      customDiffDir: path.join('path', 'to', 'my-custom-diff-dir'),
+      customFailedDir: path.join('path', 'to', 'my-custom-failed-dir'),
+      updateFailedSnapshot: true,
+      noColors: true,
+    });
+    expect.extend({ toMatchImageSnapshot });
+    const matcherAtTest = toMatchImageSnapshot.bind(mockTestContext);
+
+    matcherAtTest();
+
+    expect(runDiffImageToSnapshot).toHaveBeenCalledWith({
+      customDiffConfig: {
+        perceptual: true,
+      },
+      snapshotIdentifier: 'test-spec-js-test-1-1',
+      snapshotsDir: path.join('path', 'to', 'my-custom-snapshots-dir'),
+      failedDir: path.join('path', 'to', 'my-custom-failed-dir'),
+      diffDir: path.join('path', 'to', 'my-custom-diff-dir'),
+      diffDirection: 'horizontal',
+      updateSnapshot: false,
+      updatePassedSnapshot: false,
+      updateFailedSnapshot: true,
       failureThreshold: 0,
       failureThresholdType: 'pixel',
     });

--- a/src/index.js
+++ b/src/index.js
@@ -103,22 +103,26 @@ function configureToMatchImageSnapshot({
   customDiffConfig: commonCustomDiffConfig = {},
   customSnapshotsDir: commonCustomSnapshotsDir,
   customDiffDir: commonCustomDiffDir,
+  customFailedDir: commonCustomFailedDir,
   diffDirection: commonDiffDirection = 'horizontal',
   noColors: commonNoColors = false,
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
   updatePassedSnapshot: commonUpdatePassedSnapshot = false,
+  updateFailedSnapshot: commonUpdateFailedSnapshot = false,
 } = {}) {
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = '',
     customSnapshotsDir = commonCustomSnapshotsDir,
     customDiffDir = commonCustomDiffDir,
+    customFailedDir = commonCustomFailedDir,
     diffDirection = commonDiffDirection,
     customDiffConfig = {},
     noColors = commonNoColors,
     failureThreshold = commonFailureThreshold,
     failureThresholdType = commonFailureThresholdType,
     updatePassedSnapshot = commonUpdatePassedSnapshot,
+    updateFailedSnapshot = commonUpdateFailedSnapshot,
   } = {}) {
     const {
       testPath, currentTestName, isNot, snapshotState,
@@ -141,6 +145,7 @@ function configureToMatchImageSnapshot({
 
     const snapshotsDir = customSnapshotsDir || path.join(path.dirname(testPath), SNAPSHOTS_DIR);
     const diffDir = customDiffDir || path.join(snapshotsDir, '__diff_output__');
+    const failedDir = customFailedDir || snapshotsDir;
     const baselineSnapshotPath = path.join(snapshotsDir, `${snapshotIdentifier}-snap.png`);
 
     if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
@@ -157,6 +162,7 @@ function configureToMatchImageSnapshot({
         receivedImageBuffer: received,
         snapshotsDir,
         diffDir,
+        failedDir,
         diffDirection,
         snapshotIdentifier,
         updateSnapshot: snapshotState._updateSnapshot === 'all',
@@ -164,6 +170,7 @@ function configureToMatchImageSnapshot({
         failureThreshold,
         failureThresholdType,
         updatePassedSnapshot,
+        updateFailedSnapshot,
       });
 
     return checkResult({


### PR DESCRIPTION
Add updatedFailedSnapshots and customFailedDir properties which can for example be use to create artifacts during CI runs. 

If only updateFailedSnapshot is set to true the baseline if overwritten with the failed result.

This feature would be very useful for us, since the CI job for many screenshots runs quite long and this would allow us to create usable artifacts without running the pipeline twice.

Resolves #112 

