### PR TITLE
feat(options): add option to run diff in process

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
 * `updatePassedSnapshot`: (default `false`) Updates a snapshot even if it passed the threshold against the existing one.
+* `runInProcess`: (default `false`) Runs the diff in process without spawning a child process.
 
 ```javascript
   it('should demonstrate this matcher`s usage with a custom pixelmatch config', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const kebabCase = require('lodash/kebabCase');
 const merge = require('lodash/merge');
 const path = require('path');
 const Chalk = require('chalk').constructor;
-const { runDiffImageToSnapshot } = require('./diff-snapshot');
+const { diffImageToSnapshot, runDiffImageToSnapshot } = require('./diff-snapshot');
 const fs = require('fs');
 
 const timesCalled = new Map();
@@ -125,6 +125,7 @@ function configureToMatchImageSnapshot({
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
   updatePassedSnapshot: commonUpdatePassedSnapshot = false,
+  runInProcess: commonRunInProcess = false,
 } = {}) {
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = '',
@@ -136,6 +137,7 @@ function configureToMatchImageSnapshot({
     failureThreshold = commonFailureThreshold,
     failureThresholdType = commonFailureThresholdType,
     updatePassedSnapshot = commonUpdatePassedSnapshot,
+    runInProcess = commonRunInProcess,
   } = {}) {
     const {
       testPath, currentTestName, isNot, snapshotState,
@@ -169,8 +171,10 @@ function configureToMatchImageSnapshot({
       };
     }
 
+    const imageToSnapshot = runInProcess ? diffImageToSnapshot : runDiffImageToSnapshot;
+
     const result =
-      runDiffImageToSnapshot({
+      imageToSnapshot({
         receivedImageBuffer: received,
         snapshotsDir,
         diffDir,


### PR DESCRIPTION
This allows it to use `jest-image-snapshot` in environments where it's not possible to spawn other processes (e.g. electron render process)