### PR TITLE
chore(npm): add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+# node & npm
+*.log
+
+# test
+test-results
+__diff_output__
+.jest-cache
+__tests__
+
+# examples
+examples
+
+# IDE
+.idea


### PR DESCRIPTION
Prevents folders such as `examples` and `__tests__` from being published in the package pushed to npm. This results in a small decrease in package size.

These folders do not influence the production code and were discovered after our Windows CI output the following when running `git clean -fxdq`:

```
warning: Could not stat path 'src/desktop/node_modules/jest-image-snapshot/examples/__tests__/__image_snapshots__/puppeteer-example-spec-js-jest-image-snapshot-usage-with-an-image-received-from-puppeteer-works-1-snap.png': Filename too long
```