### PR TITLE
docs: failureThreshold should be a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The failure threshold can be set in percent, in this case if the difference is o
   it('should fail if there is more than a 1% difference', () => {
     ...
     expect(image).toMatchImageSnapshot({
-      failureThreshold: '0.01',
+      failureThreshold: 0.01,
       failureThresholdType: 'percent'
     });
   });


### PR DESCRIPTION
Update example with `failureThreshold` to use a `number` instead of `string`. Inside the type definition of `MatchImageSnapshotOptions` the expected type is `number`.

[Link to the definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest-image-snapshot/index.d.ts#L52)
