### PR TITLE
Add option to use blur on compared images

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+# node & npm
+*.log
+
+# test
+test-results
+__diff_output__
+.jest-cache
+__tests__
+
+# examples
+examples
+
+# IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
 * `updatePassedSnapshot`: (default `false`) Updates a snapshot even if it passed the threshold against the existing one.
+* `blur`: (default `0`) Applies Gaussian Blur on generated images. Useful when you have noise after scaling images per different resolutions on your target website.
 
 ```javascript
   it('should demonstrate this matcher`s usage with a custom pixelmatch config', () => {

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
 * `blur`: (default `0`) Applies Gaussian Blur on compared images, accepts radius in pixels as value. Useful when you have noise after scaling images per different resolutions on your target website, usually setting it's value to 1-2 should be enough to solve that problem.
 * `runInProcess`: (default `false`) Runs the diff in process without spawning a child process.
 
-
-
 ```javascript
   it('should demonstrate this matcher`s usage with a custom pixelmatch config', () => {
     ...

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
 * `updatePassedSnapshot`: (default `false`) Updates a snapshot even if it passed the threshold against the existing one.
-* `blur`: (default `0`) Applies Gaussian Blur on generated images. Useful when you have noise after scaling images per different resolutions on your target website.
+* `blur`: (default `0`) Applies Gaussian Blur on compared images, accepts radius in pixels as value. Useful when you have noise after scaling images per different resolutions on your target website, usually setting it's value to 1-2 should be enough to solve that problem.
 
 ```javascript
   it('should demonstrate this matcher`s usage with a custom pixelmatch config', () => {

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`toMatchImageSnapshot passes diffImageToSnapshot everything it needs to create a snapshot and compare if needed 1`] = `
 Object {
+  "blur": 0,
   "customDiffConfig": Object {},
   "diffDir": "path/to/__image_snapshots__/__diff_output__",
   "diffDirection": "horizontal",

--- a/__tests__/diff-snapshot.spec.js
+++ b/__tests__/diff-snapshot.spec.js
@@ -614,6 +614,12 @@ describe('diff-snapshot', () => {
       });
 
       expect(mockGlur).toHaveBeenCalledTimes(2);
+      expect(mockGlur).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        100,
+        100,
+        2
+      );
       expect(result.pass).toBe(true);
     });
   });

--- a/__tests__/diff-snapshot.spec.js
+++ b/__tests__/diff-snapshot.spec.js
@@ -70,6 +70,7 @@ describe('diff-snapshot', () => {
     const mockMkdirpSync = jest.fn();
     const mockWriteFileSync = jest.fn();
     const mockPixelMatch = jest.fn();
+    const mockGlur = jest.fn();
 
     function setupTest({
       snapshotDirExists,
@@ -113,6 +114,8 @@ describe('diff-snapshot', () => {
 
       jest.mock('pixelmatch', () => mockPixelMatch);
       mockPixelMatch.mockImplementation(() => pixelmatchResult);
+
+      jest.mock('glur', () => mockGlur);
 
       return diffImageToSnapshot;
     }
@@ -579,6 +582,39 @@ describe('diff-snapshot', () => {
 
       expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
       expect(diffResult).toHaveProperty('updated', true);
+    });
+
+    it('should not run glur on compared images when no value for blur param is provided', () => {
+      const diffImageToSnapshot = setupTest({ snapshotExists: true });
+      const result = diffImageToSnapshot({
+        receivedImageBuffer: mockFailImageBuffer,
+        snapshotIdentifier: mockSnapshotIdentifier,
+        snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
+        updateSnapshot: false,
+        failureThreshold: 0,
+        failureThresholdType: 'pixel',
+      });
+
+      expect(mockGlur).not.toHaveBeenCalled();
+      expect(result.pass).toBe(true);
+    });
+
+    it('should run glur on compared images when value for blur param is provided', () => {
+      const diffImageToSnapshot = setupTest({ snapshotExists: true });
+      const result = diffImageToSnapshot({
+        receivedImageBuffer: mockFailImageBuffer,
+        snapshotIdentifier: mockSnapshotIdentifier,
+        snapshotsDir: mockSnapshotsDir,
+        diffDir: mockDiffDir,
+        updateSnapshot: false,
+        failureThreshold: 0,
+        failureThresholdType: 'pixel',
+        blur: 2,
+      });
+
+      expect(mockGlur).toHaveBeenCalledTimes(2);
+      expect(result.pass).toBe(true);
     });
   });
 });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -447,6 +447,7 @@ describe('toMatchImageSnapshot', () => {
     matcherAtTest();
 
     expect(diffImageToSnapshot).toHaveBeenCalledWith({
+      blur: 0,
       customDiffConfig: {
         perceptual: true,
       },

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -391,6 +391,7 @@ describe('toMatchImageSnapshot', () => {
     matcherAtTest();
 
     expect(runDiffImageToSnapshot).toHaveBeenCalledWith({
+      blur: 0,
       customDiffConfig: {
         perceptual: true,
       },

--- a/package.json
+++ b/package.json
@@ -47,12 +47,13 @@
     "eslint-config-amex": "^7.0.0",
     "image-size": "^0.7.1",
     "jest": "^24.0.0",
-    "mock-spawn": "^0.2.6",
-    "jest-snapshot": "^23.0.0"
+    "jest-snapshot": "^23.0.0",
+    "mock-spawn": "^0.2.6"
   },
   "dependencies": {
     "chalk": "^1.1.3",
     "get-stdin": "^5.0.1",
+    "glur": "^1.1.2",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "pixelmatch": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-image-snapshot",
-  "version": "2.9.1",
+  "version": "2.9.0",
   "description": "Jest matcher for image comparisons. Most commonly used for visual regression testing.",
   "main": "src/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/americanexpress/jest-image-snapshot.git"
+    "url": "https://github.com/Alivejke/jest-image-snapshot.git"
   },
   "author": "Andres Escobar <andres.escobar@aexp.com> (https://github.com/anescobar1991)",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-image-snapshot",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Jest matcher for image comparisons. Most commonly used for visual regression testing.",
   "main": "src/index.js",
   "engines": {

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -84,7 +84,7 @@ const shouldUpdate = ({ pass, updateSnapshot, updatePassedSnapshot }) => (
   (!pass && updateSnapshot) || (pass && updatePassedSnapshot)
 );
 
-/* eslint-disable complexity */
+// eslint-disable-next-line complexity
 function diffImageToSnapshot(options) {
   const {
     receivedImageBuffer,
@@ -229,8 +229,6 @@ function diffImageToSnapshot(options) {
   }
   return result;
 }
-/* eslint-enabled */
-
 
 function runDiffImageToSnapshot(options) {
   options.receivedImageBuffer = options.receivedImageBuffer.toString('base64');

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -20,6 +20,7 @@ const pixelmatch = require('pixelmatch');
 const { PNG } = require('pngjs');
 const rimraf = require('rimraf');
 const { createHash } = require('crypto');
+const glur = require('glur');
 const ImageComposer = require('./image-composer');
 
 /**
@@ -95,6 +96,7 @@ function diffImageToSnapshot(options) {
     customDiffConfig = {},
     failureThreshold,
     failureThresholdType,
+    blur,
   } = options;
 
   let result = {};
@@ -129,6 +131,12 @@ function diffImageToSnapshot(options) {
     const [receivedImage, baselineImage] = hasSizeMismatch
       ? alignImagesToSameSize(rawReceivedImage, rawBaselineImage)
       : [rawReceivedImage, rawBaselineImage];
+
+    if (typeof blur === 'number' && blur > 0) {
+      glur(receivedImage.data, imageWidth, imageHeight, blur);
+      glur(baselineImage.data, imageWidth, imageHeight, blur);
+    }
+
     const imageWidth = receivedImage.width;
     const imageHeight = receivedImage.height;
     const diffImage = new PNG({ width: imageWidth, height: imageHeight });

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -131,14 +131,14 @@ function diffImageToSnapshot(options) {
     const [receivedImage, baselineImage] = hasSizeMismatch
       ? alignImagesToSameSize(rawReceivedImage, rawBaselineImage)
       : [rawReceivedImage, rawBaselineImage];
+    const imageWidth = receivedImage.width;
+    const imageHeight = receivedImage.height;
 
     if (typeof blur === 'number' && blur > 0) {
       glur(receivedImage.data, imageWidth, imageHeight, blur);
       glur(baselineImage.data, imageWidth, imageHeight, blur);
     }
 
-    const imageWidth = receivedImage.width;
-    const imageHeight = receivedImage.height;
     const diffImage = new PNG({ width: imageWidth, height: imageHeight });
 
     let pass = false;

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -84,6 +84,7 @@ const shouldUpdate = ({ pass, updateSnapshot, updatePassedSnapshot }) => (
   (!pass && updateSnapshot) || (pass && updatePassedSnapshot)
 );
 
+/* eslint-disable complexity */
 function diffImageToSnapshot(options) {
   const {
     receivedImageBuffer,
@@ -228,6 +229,7 @@ function diffImageToSnapshot(options) {
   }
   return result;
 }
+/* eslint-enabled */
 
 
 function runDiffImageToSnapshot(options) {

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -84,8 +84,8 @@ const shouldUpdate = ({ pass, updateSnapshot, updatePassedSnapshot }) => (
   (!pass && updateSnapshot) || (pass && updatePassedSnapshot)
 );
 
-// eslint-disable-next-line complexity
 function diffImageToSnapshot(options) {
+  /* eslint complexity: ["error", 12] */
   const {
     receivedImageBuffer,
     snapshotIdentifier,

--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,7 @@ function configureToMatchImageSnapshot({
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
   updatePassedSnapshot: commonUpdatePassedSnapshot = false,
+  blur: commonBlur = 0,
 } = {}) {
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = '',
@@ -136,6 +137,7 @@ function configureToMatchImageSnapshot({
     failureThreshold = commonFailureThreshold,
     failureThresholdType = commonFailureThresholdType,
     updatePassedSnapshot = commonUpdatePassedSnapshot,
+    blur = commonBlur,
   } = {}) {
     const {
       testPath, currentTestName, isNot, snapshotState,
@@ -181,6 +183,7 @@ function configureToMatchImageSnapshot({
         failureThreshold,
         failureThresholdType,
         updatePassedSnapshot,
+        blur,
       });
 
     return checkResult({


### PR DESCRIPTION
As in readme - Applies Gaussian Blur on generated images. Useful when you have noise after scaling images per different resolutions on your target website.

My problem was that I received a lot of random pixel differences on the same images on website between different runs because of downscaling. Applying a blur, usually 1-2 radius, removes this noise and fixes this issue