### PR TITLE
chore(packages): Upgrade from pixelmatch 4.x to 5.x

### DIFF
--- a/__tests__/integration.spec.js
+++ b/__tests__/integration.spec.js
@@ -168,7 +168,7 @@ describe('toMatchImageSnapshot', () => {
     const biggerImageData = fs.readFileSync(fromStubs('TestImage150x150.png'));
 
     it('fails for a different snapshot', () => {
-      const expectedError = /^Expected image to match or be a close match to snapshot but was 86\.55000000000001% different from snapshot \(8655 differing pixels\)\./;
+      const expectedError = /^Expected image to match or be a close match to snapshot but was 86\.45% different from snapshot \(8645 differing pixels\)\./;
       const customSnapshotIdentifier = getIdentifierIndicatingCleanupIsRequired();
 
       // Write a new snapshot image

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "glur": "^1.1.2",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
-    "pixelmatch": "^4.0.2",
+    "pixelmatch": "^5.0.2",
     "pngjs": "^3.3.3",
     "rimraf": "^2.6.2"
   },


### PR DESCRIPTION
Upgrades `pixelmatch` to latest.

https://github.com/mapbox/pixelmatch/releases/tag/v5.0.0

Noteworthy changes:

* Improve matching performance by ~35%.
* Bypass detailed comparison when image data is identical, significantly improving performance.
* Fix anti-aliasing detection on image edges.
* Breaking: update to ES6 syntax, dropping Node <6.4 and IE11 support.