### PR TITLE
docs(readme/link): incorrect URL for Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Want to get paid for your contributions to `jest-image-snapshot`?
 
 ## 📖 Table of Contents
 
-* [Features](#Features)
-* [Usage](#Usage)
-* [API](#API)
-* [Available Scripts](#Available%20Scripts)
-* [Contributing](#Contributing)
+* [Features](#-features)
+* [Usage](#-useage)
+* [API](#-api)
+* [Available Scripts](#-available-scripts)
+* [Contributing](#-contributing)
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Want to get paid for your contributions to `jest-image-snapshot`?
 ## 📖 Table of Contents
 
 * [Features](#-features)
-* [Usage](#-useage)
+* [Usage](#-usage)
 * [API](#-api)
 * [Available Scripts](#-available-scripts)
 * [Contributing](#-contributing)


### PR DESCRIPTION
Table of Contents ids didn't link to subsections of the readme.