### PR TITLE
fix: dumpDiffToConsole base64 string output

### DIFF
--- a/__tests__/diff-snapshot.spec.js
+++ b/__tests__/diff-snapshot.spec.js
@@ -186,7 +186,7 @@ describe('diff-snapshot', () => {
         pass: false,
       });
 
-      const isBase64ImgStr = result.imgSrcString.includes('data:image') && result.imgSrcString.includes('base64');
+      const isBase64ImgStr = result.imgSrcString.includes('data:image/png;base64,iV');
       expect(isBase64ImgStr).toBe(true);
 
       expect(mockPixelMatch).toHaveBeenCalledTimes(1);

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -213,7 +213,7 @@ function diffImageToSnapshot(options) {
         diffOutputPath,
         diffRatio,
         diffPixelCount,
-        imgSrcString: `data:image/png;base64,${pngBuffer}`,
+        imgSrcString: `data:image/png;base64,${pngBuffer.toString('base64')}`,
       };
     } else if (shouldUpdate({ pass, updateSnapshot, updatePassedSnapshot })) {
       mkdirp.sync(snapshotsDir);


### PR DESCRIPTION
Closes https://github.com/americanexpress/jest-image-snapshot/issues/182