### PR TITLE
chore(travis): run semantic-release on node version 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ jobs:
   include:
     # Define the release stage that runs semantic-release
     - stage: release
+      node_js:
+        - 10
+        - 12
       deploy:
         on:
           branch: master


### PR DESCRIPTION
This would enable semantic-release to run on node 10. As node 8 is not supported by semantic-release.

https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md