### PR TITLE
chore(release): update semantic-release plugin order

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
+      "@semantic-release/npm",
       "@semantic-release/git",
-      "@semantic-release/github",
-      "@semantic-release/npm"
+      "@semantic-release/github"
     ],
     "branch": "master"
   }


### PR DESCRIPTION
This updates the order of the semantic release plugins so semantic release bumps the package.json version.