### PR TITLE
Fix no colors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
 * `customDiffDir`: A custom absolute path of a directory to keep this diff in
 * `customSnapshotIdentifier`: A custom name to give this snapshot. If not provided one is computed automatically. When a function is provided it is called with an object containing `testPath`, `currentTestName`, `counter` and `defaultIdentifier` as its first argument. The function must return an identifier to use for the snapshot.
 * `diffDirection`: (default: `horizontal`) (options `horizontal` or `vertical`) Changes diff image layout direction
-* `noColors`: If set to `true`/`false` explicitly sets coloring from console output, useful if storing the results in a file
+* `noColors`: Removes coloring from console output, useful if storing the results in a file
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
 * `updatePassedSnapshot`: (default `false`) Updates a snapshot even if it passed the threshold against the existing one.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See [the examples](./examples/README.md) for more detailed usage or read about a
 * `customDiffDir`: A custom absolute path of a directory to keep this diff in
 * `customSnapshotIdentifier`: A custom name to give this snapshot. If not provided one is computed automatically. When a function is provided it is called with an object containing `testPath`, `currentTestName`, `counter` and `defaultIdentifier` as its first argument. The function must return an identifier to use for the snapshot.
 * `diffDirection`: (default: `horizontal`) (options `horizontal` or `vertical`) Changes diff image layout direction
-* `noColors`: (default `false`) Removes coloring from console output, useful if storing the results in a file
+* `noColors`: If set to `true`/`false` explicitly sets coloring from console output, useful if storing the results in a file
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
 * `updatePassedSnapshot`: (default `false`) Updates a snapshot even if it passed the threshold against the existing one.

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -35,6 +35,11 @@ exports[`toMatchImageSnapshot should fail when snapshot has a difference beyond 
 
 exports[`toMatchImageSnapshot should throw an error if used with .not matcher 1`] = `"Jest: \`.not\` cannot be used with \`.toMatchImageSnapshot()\`."`;
 
+exports[`toMatchImageSnapshot should use noColors options if passed as false and style error message 2`] = `
+"Expected image to match or be a close match to snapshot but was 40% different from snapshot (600 differing pixels).
+[1m[31mSee diff for details:[39m[22m [31mpath/to/result.png[39m"
+`;
+
 exports[`toMatchImageSnapshot should use noColors options if passed as true and not style error message 2`] = `
 "Expected image to match or be a close match to snapshot but was 40% different from snapshot (600 differing pixels).
 See diff for details: path/to/result.png"

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -33,6 +33,16 @@ exports[`toMatchImageSnapshot should fail when snapshot has a difference beyond 
 [1m[31mSee diff for details:[39m[22m [31mpath/to/result.png[39m"
 `;
 
+exports[`toMatchImageSnapshot should not style error message if colors not supported  2`] = `
+"Expected image to match or be a close match to snapshot but was 40% different from snapshot (600 differing pixels).
+See diff for details: path/to/result.png"
+`;
+
+exports[`toMatchImageSnapshot should style error message if colors supported  2`] = `
+"Expected image to match or be a close match to snapshot but was 40% different from snapshot (600 differing pixels).
+[1m[31mSee diff for details:[39m[22m [31mpath/to/result.png[39m"
+`;
+
 exports[`toMatchImageSnapshot should throw an error if used with .not matcher 1`] = `"Jest: \`.not\` cannot be used with \`.toMatchImageSnapshot()\`."`;
 
 exports[`toMatchImageSnapshot should use noColors options if passed as false and style error message 2`] = `

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -17,10 +17,12 @@ const fs = require('fs');
 const path = require('path');
 
 describe('toMatchImageSnapshot', () => {
-  function setupMock(diffImageToSnapshotResult) {
+  function setupMock(diffImageToSnapshotResult, mockSupportsColor = true) {
     jest.doMock('../src/diff-snapshot', () => ({
       runDiffImageToSnapshot: jest.fn(() => diffImageToSnapshotResult),
     }));
+
+    jest.mock('supports-color', () => mockSupportsColor);
 
     const mockFs = Object.assign({}, fs, {
       existsSync: jest.fn(),
@@ -146,12 +148,46 @@ describe('toMatchImageSnapshot', () => {
       diffRatio: 0.4,
       diffPixelCount: 600,
     };
+    const mockSupportsColor = false;
+
+    setupMock(mockDiffResult, mockSupportsColor);
+    const { toMatchImageSnapshot } = require('../src/index');
+    expect.extend({ toMatchImageSnapshot });
+
+    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot({ noColors: false }))
+      .toThrowErrorMatchingSnapshot();
+  });
+
+  it('should not style error message if colors not supported ', () => {
+    const mockDiffResult = {
+      pass: false,
+      diffOutputPath: 'path/to/result.png',
+      diffRatio: 0.4,
+      diffPixelCount: 600,
+    };
+    const mockSupportsColor = false;
+
+    setupMock(mockDiffResult, mockSupportsColor);
+    const { toMatchImageSnapshot } = require('../src/index');
+    expect.extend({ toMatchImageSnapshot });
+
+    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot())
+      .toThrowErrorMatchingSnapshot();
+  });
+
+  it('should style error message if colors supported ', () => {
+    const mockDiffResult = {
+      pass: false,
+      diffOutputPath: 'path/to/result.png',
+      diffRatio: 0.4,
+      diffPixelCount: 600,
+    };
 
     setupMock(mockDiffResult);
     const { toMatchImageSnapshot } = require('../src/index');
     expect.extend({ toMatchImageSnapshot });
 
-    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot({ noColors: false }))
+    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot())
       .toThrowErrorMatchingSnapshot();
   });
 

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -139,6 +139,22 @@ describe('toMatchImageSnapshot', () => {
       .toThrowErrorMatchingSnapshot();
   });
 
+  it('should use noColors options if passed as false and style error message', () => {
+    const mockDiffResult = {
+      pass: false,
+      diffOutputPath: 'path/to/result.png',
+      diffRatio: 0.4,
+      diffPixelCount: 600,
+    };
+
+    setupMock(mockDiffResult);
+    const { toMatchImageSnapshot } = require('../src/index');
+    expect.extend({ toMatchImageSnapshot });
+
+    expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot({ noColors: false }))
+      .toThrowErrorMatchingSnapshot();
+  });
+
   it('should use custom pixelmatch configuration if passed in', () => {
     const mockTestContext = {
       testPath: 'path/to/test.spec.js',

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "env FORCE_COLOR=1 npm test",
+      "pre-commit": "npm test",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm test",
+      "pre-commit": "env FORCE_COLOR=1 npm test",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ function configureToMatchImageSnapshot({
   customSnapshotsDir: commonCustomSnapshotsDir,
   customDiffDir: commonCustomDiffDir,
   diffDirection: commonDiffDirection = 'horizontal',
-  noColors: commonNoColors = false,
+  noColors: commonNoColors,
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
   updatePassedSnapshot: commonUpdatePassedSnapshot = false,
@@ -152,7 +152,11 @@ function configureToMatchImageSnapshot({
     const {
       testPath, currentTestName, isNot, snapshotState,
     } = this;
-    const chalk = new Chalk({ enabled: !noColors });
+    const chalkOptions = {};
+    if (typeof noColors !== 'undefined') {
+      chalkOptions.enabled = !noColors;
+    }
+    const chalk = new Chalk(chalkOptions);
 
     const retryTimes = parseInt(global[Symbol.for('RETRY_TIMES')], 10) || 0;
 


### PR DESCRIPTION
Hi!
This PR fixes `noColors` option to allow chalk auto-detect colors support.
Also, I had to add `env FORCE_COLOR=1` to the pre-commit hook: `"pre-commit": "env FORCE_COLOR=1 npm test"`. For some reasons chalk doesn't detect colors on windows 10 when executed by husky (https://github.com/typicode/husky/issues/350) and tests don't pass.

Closes #114 
