### PR TITLE
fix(options): add allowSizeMismatch arg

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -14,6 +14,7 @@ exports[`toMatchImageSnapshot dumpDiffToConsole imgSrcString is not added to con
 
 exports[`toMatchImageSnapshot passes diffImageToSnapshot everything it needs to create a snapshot and compare if needed 1`] = `
 Object {
+  "allowSizeMismatch": false,
   "blur": 0,
   "customDiffConfig": Object {},
   "diffDir": "path/to/__image_snapshots__/__diff_output__",

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -408,6 +408,7 @@ describe('toMatchImageSnapshot', () => {
     matcherAtTest();
 
     expect(runDiffImageToSnapshot).toHaveBeenCalledWith({
+      allowSizeMismatch: false,
       blur: 1,
       customDiffConfig: {
         perceptual: true,
@@ -464,6 +465,7 @@ describe('toMatchImageSnapshot', () => {
     matcherAtTest();
 
     expect(diffImageToSnapshot).toHaveBeenCalledWith({
+      allowSizeMismatch: false,
       blur: 0,
       customDiffConfig: {
         perceptual: true,

--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,7 @@ function configureToMatchImageSnapshot({
   blur: commonBlur = 0,
   runInProcess: commonRunInProcess = false,
   dumpDiffToConsole: commonDumpDiffToConsole = false,
+  allowSizeMismatch: commonAllowSizeMismatch = false,
 } = {}) {
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = commonCustomSnapshotIdentifier,
@@ -148,6 +149,7 @@ function configureToMatchImageSnapshot({
     blur = commonBlur,
     runInProcess = commonRunInProcess,
     dumpDiffToConsole = commonDumpDiffToConsole,
+    allowSizeMismatch = commonAllowSizeMismatch,
   } = {}) {
     const {
       testPath, currentTestName, isNot, snapshotState,
@@ -196,6 +198,7 @@ function configureToMatchImageSnapshot({
         failureThresholdType,
         updatePassedSnapshot,
         blur,
+        allowSizeMismatch,
       });
 
     return checkResult({


### PR DESCRIPTION
continuation of #202 with passing tests/lint (updated snapshots), formatted commit message, and rebased on master.

fixes a bug where `allowSizeMismatch` isn't working when passed to `toMatchImageSnapshot`.

