### PR TITLE
Bug/invalid mismatch message

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -14,6 +14,7 @@ exports[`toMatchImageSnapshot dumpDiffToConsole imgSrcString is not added to con
 
 exports[`toMatchImageSnapshot passes diffImageToSnapshot everything it needs to create a snapshot and compare if needed 1`] = `
 Object {
+  "allowSizeMismatch": false,
   "blur": 0,
   "customDiffConfig": Object {},
   "diffDir": "path/to/__image_snapshots__/__diff_output__",

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -408,6 +408,7 @@ describe('toMatchImageSnapshot', () => {
     matcherAtTest();
 
     expect(runDiffImageToSnapshot).toHaveBeenCalledWith({
+      allowSizeMismatch: false,
       blur: 1,
       customDiffConfig: {
         perceptual: true,
@@ -464,6 +465,7 @@ describe('toMatchImageSnapshot', () => {
     matcherAtTest();
 
     expect(diffImageToSnapshot).toHaveBeenCalledWith({
+      allowSizeMismatch: false,
       blur: 0,
       customDiffConfig: {
         perceptual: true,

--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,7 @@ function configureToMatchImageSnapshot({
   blur: commonBlur = 0,
   runInProcess: commonRunInProcess = false,
   dumpDiffToConsole: commonDumpDiffToConsole = false,
+  allowSizeMismatch: commonAllowSizeMismatch = false,
 } = {}) {
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = commonCustomSnapshotIdentifier,
@@ -148,6 +149,7 @@ function configureToMatchImageSnapshot({
     blur = commonBlur,
     runInProcess = commonRunInProcess,
     dumpDiffToConsole = commonDumpDiffToConsole,
+    allowSizeMismatch = commonAllowSizeMismatch,
   } = {}) {
     const {
       testPath, currentTestName, isNot, snapshotState,
@@ -196,6 +198,7 @@ function configureToMatchImageSnapshot({
         failureThresholdType,
         updatePassedSnapshot,
         blur,
+        allowSizeMismatch,
       });
 
     return checkResult({

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ function checkResult({
   snapshotIdentifier,
   chalk,
   dumpDiffToConsole,
+  allowSizeMismatch,
 }) {
   let pass = true;
   /*
@@ -65,7 +66,7 @@ function checkResult({
       const differencePercentage = result.diffRatio * 100;
       message = () => {
         let failure;
-        if (result.diffSize) {
+        if (result.diffSize && !allowSizeMismatch) {
           failure = `Expected image to be the same size as the snapshot (${result.imageDimensions.baselineWidth}x${result.imageDimensions.baselineHeight}), but was different (${result.imageDimensions.receivedWidth}x${result.imageDimensions.receivedHeight}).\n`;
         } else {
           failure = `Expected image to match or be a close match to snapshot but was ${differencePercentage}% different from snapshot (${result.diffPixelCount} differing pixels).\n`;
@@ -208,6 +209,7 @@ function configureToMatchImageSnapshot({
       snapshotIdentifier,
       chalk,
       dumpDiffToConsole,
+      allowSizeMismatch,
     });
   };
 }


### PR DESCRIPTION
- continuation of #202 with passing tests/lint (updated snapshots), formatted commit message, and rebased on master.
- fixes a bug where `allowSizeMismatch` isn't working when passed to `toMatchImageSnapshot`.
- fixes a bug where wrong error message was reported when `allowSizeMismatch` is true

Once the `allowSizeMismatch` option was working (fixed in #213  ), I noticed some still-failing test cases that were printing the size mismatch error (unrelated to #213 change). This PR includes a pretty small fix for that. 

When all three of the following were true:
1. the image size was different
2.  the `differencePercentage` was higher than the threshold
3. `allowSizeMismatch` is true

it would log an error for image size different, not for the threshold error.