### PR TITLE
Docs(readme): Add link to DefinitelyTyped in read me file for TypeScript users

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,12 @@ To enable this image reporter, add it to your `jest.config.js` "reporters" defin
 
 #### Usage in TypeScript
 
-In TypeScript, you can declare `toMatchImageSnapshot` like this:
+In TypeScript, you can use the [DefinitelyTyped](https://www.npmjs.com/package/@types/jest-image-snapshot) definition or declare `toMatchImageSnapshot` like the example below:
 
-```
+_Note: This package is not maintained by the `jest-image-snapshot` maintainers so it may be out of date or inaccurate. Because of this, we do not officially support it._
+
+
+```typescript
 declare global {
   namespace jest {
     interface Matchers<R> {


### PR DESCRIPTION
**Description**
There is a type definition already created in DefinitelyTyped for TypeScript users. This PR adds a link to this package in the readme file so users can easily find the types.

**DefinitelyTyped npm package**
https://www.npmjs.com/package/@types/jest-image-snapshot

**DefinitelyTyped GitHub**
https://github.com/DefinitelyTyped/DefinitelyTyped#readme