### PR TITLE
Update jest condition in peerDep in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ssim.js": "^3.1.1"
   },
   "peerDependencies": {
-    "jest": ">=20 <=27"
+    "jest": ">=20 <=26.4.2"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ssim.js": "^3.1.1"
   },
   "peerDependencies": {
-    "jest": ">=20 <=26"
+    "jest": ">=20 <=27"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Update jest peerDep in package.json

This is causing `npm install` throwing warning saying `jest-image-snapshot requires jest of some specific version with condition`