### PR TITLE
fix incorrect stats reported to jest

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,9 +57,9 @@ function checkResult({
   } else {
     ({ pass } = result);
 
-    updateSnapshotState(snapshotState, { matched: snapshotState.matched + 1 });
-
-    if (!pass) {
+    if (pass) {
+      updateSnapshotState(snapshotState, { matched: snapshotState.matched + 1 });
+    } else {
       const currentRun = timesCalled.get(snapshotIdentifier);
       if (!retryTimes || (currentRun > retryTimes)) {
         updateSnapshotState(snapshotState, { unmatched: snapshotState.unmatched + 1 });


### PR DESCRIPTION
## Description

Closes #243. See that issue for details.

## Motivation and Context

When jest finishes, the statistics shown are wrong if some snapshots failed.

## How Has This Been Tested?

There are no existing tests that assert on what is reported to jest because `UNSTABLE_SKIP_REPORTING` is enabled.

 I've tested this manually in a simple project. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~My change requires a change to the documentation and I have updated the documentation accordingly.~~
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] ~~These changes should be applied to a maintenance branch.~~
- [ ] ~~I have added the Apache 2.0 license header to any new files created.~~

## What is the Impact to Developers Using Jest-Image-Snapshot?
<!--- Please describe how your changes impacts developers using Jest-Image-Snapshot. -->

Stats reported to jest are now correct. 