### PR TITLE
chore(deps): bump chalk from `^1.1.3` to `^4.0.0`

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -22,7 +22,11 @@ describe('toMatchImageSnapshot', () => {
       runDiffImageToSnapshot: jest.fn(() => diffImageToSnapshotResult),
     }));
 
-    jest.mock('supports-color', () => mockSupportsColor);
+    jest.mock('supports-color', () => ({
+      // 1 means basic ANSI 16-color support, 0 means no support
+      stdout: { level: mockSupportsColor ? 1 : 0 },
+      stderr: { level: mockSupportsColor ? 1 : 0 },
+    }));
 
     const mockFs = Object.assign({}, fs, {
       existsSync: jest.fn(),
@@ -35,12 +39,6 @@ describe('toMatchImageSnapshot', () => {
       mockFs,
     };
   }
-
-  const ChalkMock = () => ({
-    bold: {
-      red: input => input,
-    },
-  });
 
   beforeEach(() => {
     // In tests, skip reporting (skip snapshotState update to not mess with our test report)
@@ -432,10 +430,8 @@ describe('toMatchImageSnapshot', () => {
       runDiffImageToSnapshot,
     }));
 
-    const Chalk = jest.fn();
-    jest.doMock('chalk', () => ({
-      constructor: Chalk,
-    }));
+    const Chalk = require('chalk').Instance;
+    jest.mock('chalk');
     const { toMatchImageSnapshot } = require('../src/index');
     const matcherAtTest = toMatchImageSnapshot.bind(mockTestContext);
 
@@ -478,10 +474,8 @@ describe('toMatchImageSnapshot', () => {
       runDiffImageToSnapshot,
     }));
 
-    const Chalk = jest.fn();
-    jest.doMock('chalk', () => ({
-      constructor: Chalk,
-    }));
+    const Chalk = require('chalk').Instance;
+    jest.mock('chalk');
     const { configureToMatchImageSnapshot } = require('../src/index');
     const customDiffConfig = { perceptual: true };
     const customSnapshotIdentifier = ({ defaultIdentifier }) =>
@@ -526,7 +520,7 @@ describe('toMatchImageSnapshot', () => {
       comparisonMethod,
     });
     expect(Chalk).toHaveBeenCalledWith({
-      enabled: false,
+      level: 0, // noColors
     });
   });
 
@@ -549,10 +543,8 @@ describe('toMatchImageSnapshot', () => {
       diffImageToSnapshot,
     }));
 
-    const Chalk = jest.fn();
-    jest.doMock('chalk', () => ({
-      constructor: Chalk,
-    }));
+    const Chalk = require('chalk').Instance;
+    jest.mock('chalk');
     const { configureToMatchImageSnapshot } = require('../src/index');
     const customConfig = { perceptual: true };
     const toMatchImageSnapshot = configureToMatchImageSnapshot({
@@ -588,7 +580,7 @@ describe('toMatchImageSnapshot', () => {
       comparisonMethod: 'pixelmatch',
     });
     expect(Chalk).toHaveBeenCalledWith({
-      enabled: false,
+      level: 0, // noColors
     });
   });
 
@@ -698,10 +690,6 @@ describe('toMatchImageSnapshot', () => {
       const { toMatchImageSnapshot } = require('../src/index');
       expect.extend({ toMatchImageSnapshot });
 
-      jest.doMock('chalk', () => ({
-        constructor: ChalkMock,
-      }));
-
       expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot({ dumpDiffToConsole: true }))
         .toThrowErrorMatchingSnapshot();
     });
@@ -718,10 +706,6 @@ describe('toMatchImageSnapshot', () => {
       setupMock(mockDiffResult);
       const { toMatchImageSnapshot } = require('../src/index');
       expect.extend({ toMatchImageSnapshot });
-
-      jest.doMock('chalk', () => ({
-        constructor: ChalkMock,
-      }));
 
       expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot())
         .toThrowErrorMatchingSnapshot();
@@ -745,10 +729,6 @@ describe('toMatchImageSnapshot', () => {
       const { toMatchImageSnapshot } = require('../src/index');
       expect.extend({ toMatchImageSnapshot });
 
-      jest.doMock('chalk', () => ({
-        constructor: ChalkMock,
-      }));
-
       process.env.TERM_PROGRAM = 'xterm';
 
       expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot({ dumpInlineDiffToConsole: true }))
@@ -771,10 +751,6 @@ describe('toMatchImageSnapshot', () => {
       const { toMatchImageSnapshot } = require('../src/index');
       expect.extend({ toMatchImageSnapshot });
 
-      jest.doMock('chalk', () => ({
-        constructor: ChalkMock,
-      }));
-
       process.env.TERM_PROGRAM = 'iTerm.app';
 
       expect(() => expect('pretendthisisanimagebuffer').toMatchImageSnapshot({ dumpInlineDiffToConsole: true }))
@@ -796,10 +772,6 @@ describe('toMatchImageSnapshot', () => {
       setupMock(mockDiffResult);
       const { toMatchImageSnapshot } = require('../src/index');
       expect.extend({ toMatchImageSnapshot });
-
-      jest.doMock('chalk', () => ({
-        constructor: ChalkMock,
-      }));
 
       process.env.ENABLE_INLINE_DIFF = true;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,12 +2473,31 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
     },
     "ansicolors": {
       "version": "0.3.2",
@@ -2601,10 +2620,35 @@
         "js-tokens": "^3.0.2"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
           "dev": true
         }
       }
@@ -2973,15 +3017,12 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       }
     },
     "char-regex": {
@@ -3098,7 +3139,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -3677,7 +3718,7 @@
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
     "deep-extend": {
@@ -3887,7 +3928,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "6.8.0",
@@ -4405,7 +4447,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true
     },
     "expect": {
@@ -4799,7 +4841,8 @@
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -7718,7 +7761,7 @@
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
     "node-releases": {
@@ -12414,6 +12457,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -12443,9 +12487,19 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        }
+      }
     },
     "supports-hyperlinks": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "semantic-release": "^17.0.4"
   },
   "dependencies": {
-    "chalk": "^1.1.3",
+    "chalk": "^4.0.0",
     "get-stdin": "^5.0.1",
     "glur": "^1.1.2",
     "lodash": "^4.17.4",

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@
 const kebabCase = require('lodash/kebabCase');
 const merge = require('lodash/merge');
 const path = require('path');
-const Chalk = require('chalk').constructor;
+const Chalk = require('chalk').Instance;
 const { diffImageToSnapshot, runDiffImageToSnapshot } = require('./diff-snapshot');
 const fs = require('fs');
 const OutdatedSnapshotReporter = require('./outdated-snapshot-reporter');
@@ -174,7 +174,8 @@ function configureToMatchImageSnapshot({
     } = this;
     const chalkOptions = {};
     if (typeof noColors !== 'undefined') {
-      chalkOptions.enabled = !noColors;
+      // 1 means basic ANSI 16-color support, 0 means no support
+      chalkOptions.level = noColors ? 0 : 1;
     }
     const chalk = new Chalk(chalkOptions);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bumps [chalk][1] from `^1.1.3` to `^4.0.0`.
- [Release notes](https://github.com/chalk/chalk/releases)
  - [v2.0.0](https://github.com/chalk/chalk/releases/tag/v2.0.0)
  - [v3.0.0](https://github.com/chalk/chalk/releases/tag/v3.0.0)
  - [v4.0.0](https://github.com/chalk/chalk/releases/tag/v4.0.0)
- [Commits](https://github.com/chalk/chalk/compare/v1.1.3...v4.0.0)

Chalk's major changes were:
  - Minimum required Node version is Node v10 (v4)
  - `chalk.constructor` has been replaced with `chalk.Instance` (v3)
  - `chalk.enabled` has been replaced with `chalk.level` (v3)

[1]: https://www.npmjs.com/package/chalk

## Motivation and Context

Jest v28 uses Chalk v4 as a dependency, so using the same version in jest-image-snapshot will mean users only need to download one version of chalk.

## How Has This Been Tested?

`jest` tests pass.

I've tried testing this branch on [my own project (remark-mermaid-dataurl)](https://github.com/aloisklink/remark-mermaid-dataurl) using the following, and it works fine.

```json
    "jest-image-snapshot": "git+https://github.com/aloisklink/jest-image-snapshot.git#chore/update-chalk-to-v4",
```

Additionally, my `package-lock.json` file lost 107 lines, so a bunch of packages were no longer needed.

```console
alois@computer:~/Documents/remark-mermaid-dataurl (master)$ git diff --stat package-lock.json
 package-lock.json | 115 ++++++++-----------------------------------------------------------------------------------------------------------
 1 file changed, 8 insertions(+), 107 deletions(-)
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- ~[ ] My change requires a change to the documentation and I have updated the documentation accordingly.~ No change required.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
  - Not 100% sure, but I don't think this applies.
- [x] I have added the Apache 2.0 license header to any new files created.
  - No files changed.

## What is the Impact to Developers Using Jest-Image-Snapshot?

No major changes, except that their `package-lock.json` file should be slightly simpler, and their `node_modules` folder slightly smaller (assuming that they have no other packages that rely on `chalk` v1).
