### PR TITLE
build: make jest optional peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,11 @@
   "peerDependencies": {
     "jest": ">=20 <=29"
   },
+  "peerDependenciesMeta": {
+    "jest": {
+      "optional": true
+    }
+  },
   "husky": {
     "hooks": {
       "pre-commit": "npm test",


### PR DESCRIPTION
Resolves #313.

## Description

Makes `jest` peerDependency less strict, because some other testing libraries also support that `jest.extend` interface apparently (according to #313).

## Motivation and Context

I was passing by that issue and decided to help. 🤷‍♂️ 

## How Has This Been Tested?

This is a relatively trivial change.

## Types of Changes

- [x] Dependency update

## Checklist:

- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.

## What is the Impact to Developers Using Jest-Image-Snapshot?

The library still would warn about incorrect Jest versions but it should not complain about Jest not being installed.
