### PR TITLE
ci: windows & mac

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -13,7 +13,7 @@ jobs:
         node: [ '14.x', '16.x', '18.x' ]
     name: Node ${{ matrix.node }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: |
         git remote set-branches --add origin main
         git fetch

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -7,10 +7,11 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [ '14.x', '16.x', '18.x' ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     name: Node ${{ matrix.node }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -12,7 +12,7 @@ jobs:
         node: [ '14.x', '16.x', '18.x' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
-    name: Node ${{ matrix.node }}
+    name: Node ${{ matrix.node }} - ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup Node.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,11 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [ '14.x', '16.x', '18.x' ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     name: Node ${{ matrix.node }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         node: [ '14.x', '16.x', '18.x' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
-    name: Node ${{ matrix.node }}
+    name: Node ${{ matrix.node }} - ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Node ${{ matrix.node }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: |
         git remote set-branches --add origin main
         git fetch

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -448,7 +448,7 @@ describe('toMatchImageSnapshot', () => {
       failureThresholdType: 'pixel',
       receivedImageBuffer: undefined,
       snapshotIdentifier: 'test-spec-js-test-1-1-snap',
-      snapshotsDir: 'path/to/__image_snapshots__',
+      snapshotsDir: process.platform === 'win32' ? 'path\\to\\__image_snapshots__' : 'path/to/__image_snapshots__',
       storeReceivedOnFailure: false,
       updatePassedSnapshot: false,
       updateSnapshot: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a matrix to run the CI on Windows, Mac, and Linux, and fixes a broken test on windows because of a different path name

## Motivation and Context
To stop operating system regressions and allow for testing the repository in a Windows development environment.

## Types of Change
- [x] Testing change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [x] These changes should be applied to a maintenance branch.
- [x] I added the Apache 2.0 license header to any new files.

## What is the Impact on Developers Using Jest-Image-Snapshot?
Very little - this stops possible regressions in path systems, as what happened with https://github.com/privatenumber/pkgroll/issues/10
