### PR TITLE
chore: replace chalk and lodash with picocolors and native code

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -22,11 +22,14 @@ describe('toMatchImageSnapshot', () => {
       runDiffImageToSnapshot: jest.fn(() => diffImageToSnapshotResult),
     }));
 
-    jest.mock('supports-color', () => ({
-      // 1 means basic ANSI 16-color support, 0 means no support
-      stdout: { level: mockSupportsColor ? 1 : 0 },
-      stderr: { level: mockSupportsColor ? 1 : 0 },
-    }));
+    // Control picocolors color detection via FORCE_COLOR / NO_COLOR env vars
+    if (mockSupportsColor) {
+      process.env.FORCE_COLOR = '1';
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = '1';
+      delete process.env.FORCE_COLOR;
+    }
 
     const mockFs = Object.assign({}, fs, {
       existsSync: jest.fn(),
@@ -40,6 +43,9 @@ describe('toMatchImageSnapshot', () => {
     };
   }
 
+  const originalForceColor = process.env.FORCE_COLOR;
+  const originalNoColor = process.env.NO_COLOR;
+
   beforeEach(() => {
     // In tests, skip reporting (skip snapshotState update to not mess with our test report)
     global.UNSTABLE_SKIP_REPORTING = true;
@@ -49,7 +55,18 @@ describe('toMatchImageSnapshot', () => {
 
   afterEach(() => {
     jest.unmock('fs');
-    jest.unmock('chalk');
+    jest.unmock('picocolors');
+    // Restore original color env vars
+    if (originalForceColor !== undefined) {
+      process.env.FORCE_COLOR = originalForceColor;
+    } else {
+      delete process.env.FORCE_COLOR;
+    }
+    if (originalNoColor !== undefined) {
+      process.env.NO_COLOR = originalNoColor;
+    } else {
+      delete process.env.NO_COLOR;
+    }
   });
 
   it('should throw an error if used with .not matcher', () => {
@@ -430,8 +447,8 @@ describe('toMatchImageSnapshot', () => {
       runDiffImageToSnapshot,
     }));
 
-    const Chalk = require('chalk').Instance;
-    jest.mock('chalk');
+    const { createColors } = require('picocolors');
+    jest.mock('picocolors');
     const { toMatchImageSnapshot } = require('../src/index');
     const matcherAtTest = toMatchImageSnapshot.bind(mockTestContext);
 
@@ -459,7 +476,7 @@ describe('toMatchImageSnapshot', () => {
       updatePassedSnapshot: false,
       updateSnapshot: false,
     });
-    expect(Chalk).toHaveBeenCalledWith({});
+    expect(createColors).toHaveBeenCalledWith();
   });
 
   it('can provide custom defaults', () => {
@@ -481,8 +498,8 @@ describe('toMatchImageSnapshot', () => {
       runDiffImageToSnapshot,
     }));
 
-    const Chalk = require('chalk').Instance;
-    jest.mock('chalk');
+    const { createColors } = require('picocolors');
+    jest.mock('picocolors');
     const { configureToMatchImageSnapshot } = require('../src/index');
     const customDiffConfig = { perceptual: true };
     const customSnapshotIdentifier = ({ defaultIdentifier }) =>
@@ -533,9 +550,7 @@ describe('toMatchImageSnapshot', () => {
       maxChildProcessBufferSizeInBytes: 1024 * 1024,
       comparisonMethod,
     });
-    expect(Chalk).toHaveBeenCalledWith({
-      level: 0, // noColors
-    });
+    expect(createColors).toHaveBeenCalledWith(false);
   });
 
   it('can run in process', () => {
@@ -557,8 +572,8 @@ describe('toMatchImageSnapshot', () => {
       diffImageToSnapshot,
     }));
 
-    const Chalk = require('chalk').Instance;
-    jest.mock('chalk');
+    const { createColors } = require('picocolors');
+    jest.mock('picocolors');
     const { configureToMatchImageSnapshot } = require('../src/index');
     const customConfig = { perceptual: true };
     const toMatchImageSnapshot = configureToMatchImageSnapshot({
@@ -599,9 +614,7 @@ describe('toMatchImageSnapshot', () => {
       comparisonMethod: 'pixelmatch',
       currentTestName: 'test1',
     });
-    expect(Chalk).toHaveBeenCalledWith({
-      level: 0, // noColors
-    });
+    expect(createColors).toHaveBeenCalledWith(false);
   });
 
   it('should only increment matched when test passed', () => {

--- a/__tests__/integration.spec.js
+++ b/__tests__/integration.spec.js
@@ -15,7 +15,8 @@
 const fs = require('fs');
 const path = require('path');
 const { rimrafSync } = require('rimraf');
-const uniqueId = require('lodash/uniqueId');
+let uniqueCounter = 0;
+const uniqueId = (prefix = '') => `${prefix}${++uniqueCounter}`; // eslint-disable-line no-plusplus
 const sizeOf = require('image-size');
 const { SnapshotState } = require('jest-snapshot');
 const { toMatchImageSnapshot } = require('../src');

--- a/examples/image-reporter.js
+++ b/examples/image-reporter.js
@@ -5,7 +5,7 @@
     "reporters": [ "default", "<rootDir>/image-reporter.js" ]
  */
 
-const chalk = require('chalk');
+const pc = require('picocolors');
 const fs = require('fs');
 const AWS = require('aws-sdk/global');
 const S3 = require('aws-sdk/clients/s3');
@@ -35,7 +35,7 @@ class ImageReporter {
           if (err) {
             console.log(err, err.stack);
           } else {
-            console.log(chalk.red.bold(`Uploaded image diff file to https://${UPLOAD_BUCKET}.s3.amazonaws.com/${path}`));
+            console.log(pc.red(pc.bold(`Uploaded image diff file to https://${UPLOAD_BUCKET}.s3.amazonaws.com/${path}`)));
           }
         });
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,9 @@
       "version": "6.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^4.0.0",
         "get-stdin": "^5.0.1",
         "glur": "^1.1.2",
-        "lodash": "^4.17.4",
+        "picocolors": "^1.1.1",
         "pixelmatch": "^5.1.0",
         "pngjs": "^3.4.0",
         "ssim.js": "^3.1.1"
@@ -139,6 +138,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1611,6 +1611,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2840,7 +2841,8 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
       "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -3177,6 +3179,7 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3340,6 +3343,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3949,6 +3953,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -4059,6 +4064,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4283,6 +4289,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4295,6 +4302,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/compare-func": {
@@ -4461,6 +4469,7 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -5318,6 +5327,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -5478,6 +5488,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5558,6 +5569,7 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -5588,6 +5600,7 @@
       "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -5920,6 +5933,7 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6811,6 +6825,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7970,6 +7985,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.0.5.tgz",
       "integrity": "sha512-y2mfcJywuTUkvLm2Lp1/pFX8kTgMO5yyQGq/Sk/n2mN7XWYp4JsCZ/QXW34M8YScgk8bPZlREH04f6blPnoHnQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.5",
         "@jest/types": "30.0.5",
@@ -8970,6 +8986,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -9180,6 +9197,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11544,6 +11562,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12153,7 +12172,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -13164,6 +13182,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -14515,6 +14534,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14874,6 +14894,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14952,6 +14973,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15171,6 +15193,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -61,10 +61,9 @@
     "semantic-release": "^25.0.2"
   },
   "dependencies": {
-    "chalk": "^4.0.0",
     "get-stdin": "^5.0.1",
     "glur": "^1.1.2",
-    "lodash": "^4.17.4",
+    "picocolors": "^1.1.1",
     "pixelmatch": "^5.1.0",
     "pngjs": "^3.4.0",
     "ssim.js": "^3.1.1"

--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,33 @@
  * the License.
  */
 /* eslint-disable no-underscore-dangle */
-const kebabCase = require('lodash/kebabCase');
-const merge = require('lodash/merge');
 const path = require('path');
-const Chalk = require('chalk').Instance;
+const { createColors } = require('picocolors');
 const { diffImageToSnapshot, runDiffImageToSnapshot } = require('./diff-snapshot');
 const fs = require('fs');
 const OutdatedSnapshotReporter = require('./outdated-snapshot-reporter');
+
+/**
+ * Converts a string to kebab-case.
+ * Handles camelCase, PascalCase, spaces, dots, underscores, and hyphens.
+ * Equivalent to lodash/kebabCase for snapshot identifier generation.
+ */
+function kebabCase(str) {
+  return String(str)
+    // Insert a hyphen between a lowercase letter and an uppercase letter (camelCase boundary)
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    // Insert a hyphen between consecutive uppercase letters followed by a lowercase (e.g. "XMLParser" -> "XML-Parser")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    // Insert a hyphen between a letter and a digit (e.g. "test1" -> "test-1")
+    .replace(/([a-zA-Z])(\d)/g, '$1-$2')
+    // Insert a hyphen between a digit and a letter (e.g. "1test" -> "1-test")
+    .replace(/(\d)([a-zA-Z])/g, '$1-$2')
+    .toLowerCase()
+    // Replace any non-alphanumeric character (or sequence) with a single hyphen
+    .replace(/[^a-z0-9]+/g, '-')
+    // Trim leading/trailing hyphens
+    .replace(/^-|-$/g, '');
+}
 
 const timesCalled = new Map();
 
@@ -39,7 +59,7 @@ function updateSnapshotState(originalSnapshotState, partialSnapshotState) {
   if (global.UNSTABLE_SKIP_REPORTING) {
     return originalSnapshotState;
   }
-  return merge(originalSnapshotState, partialSnapshotState);
+  return Object.assign(originalSnapshotState, partialSnapshotState);
 }
 
 function checkResult({
@@ -85,7 +105,7 @@ function checkResult({
           failure = `Expected image to match or be a close match to snapshot but was ${differencePercentage}% different from snapshot (${result.diffPixelCount} differing pixels).\n`;
         }
 
-        failure += `${chalk.bold.red('See diff for details:')} ${chalk.red(result.diffOutputPath)}`;
+        failure += `${chalk.bold(chalk.red('See diff for details:'))} ${chalk.red(result.diffOutputPath)}`;
 
         const supportedInlineTerms = [
           'iTerm.app',
@@ -95,7 +115,7 @@ function checkResult({
         if (dumpInlineDiffToConsole && (supportedInlineTerms.includes(process.env.TERM_PROGRAM) || 'ENABLE_INLINE_DIFF' in process.env)) {
           failure += `\n\n\t\x1b]1337;File=name=${Buffer.from(result.diffOutputPath).toString('base64')};inline=1;width=40:${result.imgSrcString.replace('data:image/png;base64,', '')}\x07\x1b\n\n`;
         } else if (dumpDiffToConsole || dumpInlineDiffToConsole) {
-          failure += `\n${chalk.bold.red('Or paste below image diff string to your browser`s URL bar.')}\n ${result.imgSrcString}`;
+          failure += `\n${chalk.bold(chalk.red('Or paste below image diff string to your browser`s URL bar.'))}\n ${result.imgSrcString}`;
         }
 
         return failure;
@@ -194,12 +214,9 @@ function configureToMatchImageSnapshot({
     const {
       testPath, currentTestName, isNot, snapshotState,
     } = this;
-    const chalkOptions = {};
-    if (typeof noColors !== 'undefined') {
-      // 1 means basic ANSI 16-color support, 0 means no support
-      chalkOptions.level = noColors ? 0 : 1;
-    }
-    const chalk = new Chalk(chalkOptions);
+    const chalk = typeof noColors !== 'undefined'
+      ? createColors(!noColors)
+      : createColors();
 
     const retryTimes = parseInt(global[Symbol.for('RETRY_TIMES')], 10) || 0;
 
@@ -225,7 +242,7 @@ function configureToMatchImageSnapshot({
     if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(baselineSnapshotPath)) {
       return {
         pass: false,
-        message: () => `New snapshot was ${chalk.bold.red('not written')}. The update flag must be explicitly ` +
+        message: () => `New snapshot was ${chalk.bold(chalk.red('not written'))}. The update flag must be explicitly ` +
         'passed to write a new snapshot.\n\n + This is likely because this test is run in a continuous ' +
         'integration (CI) environment in which snapshots are not written by default.\n\n',
       };


### PR DESCRIPTION
## Summary
Removes `chalk` and `lodash` dependencies, replacing with `picocolors` (~6KB) and native JavaScript equivalents. Net dependency reduction of ~639KB.

### Changes
- **src/index.js**: chalk.Instance → picocolors.createColors, lodash/kebabCase → inline function, lodash/merge → Object.assign
- **__tests__/index.spec.js**: Updated 3 test blocks for picocolors mock pattern
- **__tests__/integration.spec.js**: lodash/uniqueId → inline counter
- **examples/image-reporter.js**: chalk → picocolors
- **package.json**: -chalk -lodash +picocolors

### Test Results
- 101/104 tests pass (3 pre-existing failures in outdated-snapshot-reporter.spec.js, reproducible on unmodified main)
- 15/15 snapshots pass (ANSI escape sequences identical between chalk and picocolors)
- 100% code coverage on all source files

Closes #378