### PR TITLE
🚀 Feature: Add path output to matcher result for custom reporter access

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,9 @@ function checkResult({
   return {
     message,
     pass,
+    baselinePath: result.snapshot,
+    receivedPath: result.receivedImagePath,
+    diffPath: result.diffOutputPath,
   };
 }
 


### PR DESCRIPTION
## 🚀 New Feature

### Problem
The current `toMatchImageSnapshot` matcher doesn't expose the file paths (baseline, received, diff) in the Jest result object that custom reporters can access. We need to modify the matcher to include this data in the test result, allowing users to create custom reporters that display interactive diffs.

**Severity**: `high`
**File**: `src/index.js`

### Solution
The current `toMatchImageSnapshot` matcher doesn't expose the file paths (baseline, received, diff) in the Jest result object that custom reporters can access. We need to modify the matcher to include this data in the test result, allowing users to create custom reporters that display interactive diffs.

### Changes
- `src/index.js` (modified)



## Description


## Motivation and Context



## How Has This Been Tested?




## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:


- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Jest-Image-Snapshot?


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #51